### PR TITLE
Add permanent redirects to community page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -4,5 +4,5 @@
 https://openebs.netlify.com/*      https://openebs.io/:splat    301!
 http://openebs.netlify.com/*       https://openebs.io/:splat    301!
 
-/join-our-community              /community
-/join-our-slack-community        /community
+/join-our-community              /community           301!
+/join-our-slack-community        /community           301!


### PR DESCRIPTION
Signed-off-by: isamrish <askmaurya48@gmail.com>

This commit will add permanent redirect to

https://openebs.io/community from https://openebs.io/join-our-slack-community

https://openebs.io/community from https://openebs.io/join-our-community

Why above changes?
If it is not permanently redirected, in future link may behave abruptly due to upcoming shadowing
feature on netlify.