### PR TITLE
update slack links to K8s slack

### DIFF
--- a/src/views/community/slack-card.js
+++ b/src/views/community/slack-card.js
@@ -74,7 +74,11 @@ const SlackCard = () => (
                         style={{ maxWidth: '25%' }}
                       />
                       <Styled.h4 sx={{ pt: '5', fontWeight: '600' }}>
-                        Join OpenEBS Community on Slack
+                        Join OpenEBS Community on <Styled.a
+                          href="https://kubernetes.slack.com/messages/openebs/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >Kubernetes Slack </Styled.a>{' '}
                       </Styled.h4>
                       <hr
                         sx={{ width: '40%', borderTop: '2px solid #0063FF' }}
@@ -109,7 +113,7 @@ const SlackCard = () => (
                     }}
                   >
                     <iframe
-                      src="https://heroku-slackinn.herokuapp.com/"
+                      src="https://slack.k8s.io/"
                       sx={{
                         display: 'flex',
                         justifyContent: 'center',


### PR DESCRIPTION
Ref: https://github.com/openebs/openebs/issues/3053

Updating the slack sign-up page to slack.k8s.io and also added a direct link to OpenEBS channel. 