### PR TITLE
Add support section in homepage as well as improve support page

### DIFF
--- a/src/data/pages/support.md
+++ b/src/data/pages/support.md
@@ -6,7 +6,7 @@ title: 'support'
 
 This is a list of third-party companies and individuals who provide products or services related to OpenEBS. OpenEBS is an independent open source project which does not endorse any company. The list is provided in alphabetical order.
 
-- [Clouds Sky GmbH](https://cloudssky.com/en/)
-- [CodeWave](https://codewave.eu/)
-- [Gridworkz Cloud Services](https://www.gridworkz.com/)
-- [MayaData](https://mayadata.io)
+- [Clouds Sky GmbH](https://cloudssky.com/en/) - The makers of TK8, a cloud agnostic open source tool which helps you to deploy Kubernetes on any cloud in an uniform and homogeneous way.
+- [CodeWave](https://codewave.eu/) - A performance and scalability-focused web development firm that delivers custom software solutions and operates cloud-based infrastructure.
+- [Gridworkz Cloud Services](https://www.gridworkz.com/) - DevOps Cloud Services specializing in Kubernetes and ERP systems.
+- [MayaData](https://mayadata.io) - Primary contributors to OpenEBS and creators of Kubera, the fully featured free toolset to extend OpenEBS to more use cases.

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -145,6 +145,10 @@ export default {
       },
     },
     li: {
+      color: 'text',
+      fontFamily: 'body',
+      fontWeight: 'body',
+      lineHeight: 'body',
       mb: 2,
     },
     pre: {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,7 @@ import {
   Cncf,
   WhatIsOpenEBS,
   RecentUpdates,
-  GetStarted,
+  GetSupport,
   Features,
   WhyOpenEBS,
   Hero,
@@ -32,8 +32,8 @@ const IndexPage = ({ location }) => {
       <WhyOpenEBS />
       <Platforms />
       <Workloads />
+      <GetSupport location={location} />
       <RecentUpdates />
-      <GetStarted location={location} />
       <Features />
       <Cncf />
     </Layout>

--- a/src/views/get-started/get-started.js
+++ b/src/views/get-started/get-started.js
@@ -31,8 +31,8 @@ const Faq = () => {
     },
     {
       src: `get-started/monitoring.png`,
-      url: `https://mayadata.io`,
-      text: `Get Commercial Support and add DR & other features with Kubera`,
+      url: `/support`,
+      text: `Get Commercial Support and add DR & other features with products like Kubera`,
     },
   ]
 

--- a/src/views/get-started/get-started.js
+++ b/src/views/get-started/get-started.js
@@ -32,7 +32,7 @@ const Faq = () => {
     {
       src: `get-started/monitoring.png`,
       url: `https://mayadata.io`,
-      text: `Unlock the Additional Features and Free Monitoring for OpenEBS`,
+      text: `Get Commercial Support and add DR & other features with Kubera`,
     },
   ]
 

--- a/src/views/home/homepage-getsupport.js
+++ b/src/views/home/homepage-getsupport.js
@@ -3,19 +3,19 @@ import { jsx, Styled } from 'theme-ui'
 import React from 'react'
 import { Link } from 'gatsby'
 import { Container, Button } from '@theme-ui/components'
-const GetStarted = ({ location }) => {
+const GetSupport = ({ location }) => {
   return (
     <>
       <Styled.div sx={{ bg: 'primary', py: ['4', '4', '5'] }}>
         <Container>
           <Styled.div sx={{ textAlign: 'center' }}>
-            <Styled.h2 sx={{ pb: '3', color: 'white' }}>Get Started</Styled.h2>
+            <Styled.h2 sx={{ pb: '3', color: 'white' }}>Get Support</Styled.h2>
             <Styled.h4 sx={{ pb: '4', color: 'white' }}>
-              Get set up with your first OpenEBS cluster in under 90 seconds
+              Need help in getting OpenEBS up and running? Get support when you
+              need it by visiting our support center!
             </Styled.h4>
-
             <Link
-              to="/get-started"
+              to="/support"
               sx={{ display: ['block', 'block', 'inline-block'] }}
             >
               <Button
@@ -29,25 +29,7 @@ const GetStarted = ({ location }) => {
                   },
                 }}
               >
-                Start Now
-              </Button>
-            </Link>
-            <Link
-              to="/community"
-              sx={{ display: ['block', 'block', 'inline-block'] }}
-            >
-              <Button
-                sx={{
-                  bg: 'white',
-                  color: 'primary',
-                  mx: ['0', '0', '4'],
-                  mb: ['4', '4', '0'],
-                  '&:focus': {
-                    color: 'white',
-                  },
-                }}
-              >
-                Join Our Community
+                Get Support
               </Button>
             </Link>
           </Styled.div>
@@ -57,4 +39,4 @@ const GetStarted = ({ location }) => {
   )
 }
 
-export default GetStarted
+export default GetSupport

--- a/src/views/home/index.js
+++ b/src/views/home/index.js
@@ -1,5 +1,5 @@
 export { default as Cncf } from './homepage-cncf'
-export { default as GetStarted } from './homepage-getstarted'
+export { default as GetSupport } from './homepage-getsupport'
 export { default as Features } from './homepage-features'
 export { default as RecentUpdates } from './homepage-recentupdates'
 export { default as WhatIsOpenEBS } from './homepage-whatisopenebs'


### PR DESCRIPTION
Signed-off-by: isamrish <askmaurya48@gmail.com>

This PR will do
- Remove `Get Started` section from Home Page
- Add get support section in Home Page
- Update card content in the Get Started Page
- Update content in support page

Screenshots

**Before : Homepage**
![openebs-io-homepage-prev](https://user-images.githubusercontent.com/6524419/86480390-8c3a4200-bd6b-11ea-9b87-21b1613287ab.png)

**After : Homepage**
![openebs-io-homepage-after](https://user-images.githubusercontent.com/6524419/86480489-b855c300-bd6b-11ea-8efc-affada7ff642.png)


**Before: Support Pge**
![Before-support](https://user-images.githubusercontent.com/6524419/86480557-de7b6300-bd6b-11ea-9602-65e1a3b09e06.png)

**After: Support Page**
![After-support](https://user-images.githubusercontent.com/6524419/86480626-fc48c800-bd6b-11ea-9ed6-60d0bb42784d.png)


**Before: Get started**
![before-get-started](https://user-images.githubusercontent.com/6524419/86480695-21d5d180-bd6c-11ea-9f25-1c09bc22188a.png)

**After: Get started page**
![after-get-started](https://user-images.githubusercontent.com/6524419/86480761-403bcd00-bd6c-11ea-8ed1-002bb543f77b.png)
