### PR TITLE
Update asciinema theme according to new design #79

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7203,9 +7203,9 @@
       "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -9924,11 +9924,6 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
     },
-    "nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -11730,13 +11725,20 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "8.2.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-          "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+          "version": "8.2.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+          "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
           "requires": {
             "colorette": "^1.2.2",
-            "nanoid": "^3.1.20",
+            "nanoid": "^3.1.23",
             "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "nanoid": {
+              "version": "3.1.23",
+              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+              "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+            }
           }
         }
       }
@@ -15771,8 +15773,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/public/css/custom-asciinema-player.css
+++ b/public/css/custom-asciinema-player.css
@@ -18,6 +18,10 @@
   border-color: #FEFBFB;
 }
 
+.asciinema-theme-asciinema .fg-bg {
+  color: #fff;
+}
+
 .asciinema-theme-asciinema .bg-fg {    /* inverse for terminal background color */
   background-color: #073D47;
 }

--- a/public/css/custom-asciinema-player.css
+++ b/public/css/custom-asciinema-player.css
@@ -1,5 +1,5 @@
 .asciinema-terminal {
-  height: 320px !important;
+  height: 340px !important;
   width: 80vw !important;
   border-radius: 5px !important;
 }
@@ -8,39 +8,55 @@
   display: none !important;
 }
 
+.asciinema-terminal.font-small {
+  font-size: 11px;
+}
+
+.asciinema-theme-asciinema .asciinema-terminal {
+  color: #073D47;                    /* default text color */
+  background-color: #FEFBFB;         /* terminal background color */
+  border-color: #FEFBFB;
+}
+
+.asciinema-theme-asciinema .bg-fg {    /* inverse for terminal background color */
+  background-color: #073D47;
+}
 @media screen and (max-width: 639px) {
   .asciinema-terminal {
-    height: 320px !important;
-    width: 80vw !important;
+    height: 150px !important;
+    width: 290px !important;
     overflow-x: none;
+  }
+  .asciinema-terminal.font-small {
+    font-size: 6px;
   }
 }
 
 @media screen and (min-width: 640px) {
   .asciinema-terminal {
-    height: 320px !important;
-    width: 80vw !important;
+    height: 240px !important;
+    width: 480px !important;
     overflow-x: none;
   }
 }
 
 @media screen and (min-width: 896px) {
   .asciinema-terminal {
-    height: 320px !important;
+    height: 340px !important;
     width: 45vw !important;
   }
 }
 
 @media screen and (min-width: 1024px) {
   .asciinema-terminal {
-    height: 320px !important;
-    width: 45vw !important;
+    height: 210px !important;
+    width: 420px !important;
   }
 }
 
 @media screen and (min-width: 1240px) {
   .asciinema-terminal {
-    height: 185px !important;
+    height: 190px !important;
     width: 600px !important;
   }
 }

--- a/src/pages/Home/styles.ts
+++ b/src/pages/Home/styles.ts
@@ -262,8 +262,14 @@ const useStyles = makeStyles((theme) => ({
         },
     },
     desktopImage: {
+        minWidth: '650px',
+        [theme.breakpoints.down('md')]: {
+            width: '100%',
+            minWidth: '580px',
+        },
         [theme.breakpoints.down('xs')]: {
-            width: '100%'
+            width: '100%',
+            minWidth: '400px',
         },
     },
     installationButton: {
@@ -288,10 +294,11 @@ const useStyles = makeStyles((theme) => ({
         color: theme.palette.background.paper
     },
     installationButtonsWrapper: {
-        margin: theme.spacing(5, 0),
+        margin: theme.spacing(8, 0),
         [theme.breakpoints.down('sm')]: {
             display: 'flex',
-            flexDirection: 'column'
+            flexDirection: 'column',
+            margin: theme.spacing(2, 0),
         },
     },
     installationLeftButton: {
@@ -317,14 +324,14 @@ const useStyles = makeStyles((theme) => ({
     installationProviderCommandWrapper: {
         position: 'absolute',
         top: '0',
-        padding: theme.spacing(6,10.3),
+        padding: theme.spacing(6,10),
         width: '100%',
         color: theme.palette.success.dark,
         [theme.breakpoints.down('sm')]: {
-            padding: theme.spacing(6,16),
+            padding: theme.spacing(6,12),
         },
         [theme.breakpoints.down('xs')]: {
-            padding: theme.spacing(3,6),
+            padding: theme.spacing(3,2),
         },
     },
     installationProvider: {


### PR DESCRIPTION
Signed-off-by: Pallavi-PH <pallaviph02@gmail.com>

In this PR,

1. We are updating asciinema code theme according to the new design
2. We are handling responsiveness of the ascinema code block across different devices

**Desktop and laptop:**

<img width="1081" alt="Screenshot 2021-05-17 at 5 11 46 PM" src="https://user-images.githubusercontent.com/34312966/118492095-4d239e00-b73d-11eb-94d7-964208315927.png">

<img width="760" alt="Screenshot 2021-05-17 at 5 12 17 PM" src="https://user-images.githubusercontent.com/34312966/118492131-59a7f680-b73d-11eb-9a2e-ca887ee42151.png">

<img width="691" alt="Screenshot 2021-05-17 at 5 12 36 PM" src="https://user-images.githubusercontent.com/34312966/118492165-6298c800-b73d-11eb-90e9-0e2aff79d3ba.png">


**Tablet:**

<img width="767" alt="Screenshot 2021-05-17 at 5 44 22 PM" src="https://user-images.githubusercontent.com/34312966/118492200-6cbac680-b73d-11eb-8dba-8b8ff6c151b4.png">


**Mobile:**

<img width="292" alt="Screenshot 2021-05-17 at 5 43 45 PM" src="https://user-images.githubusercontent.com/34312966/118492234-75130180-b73d-11eb-9068-412f99a63fe7.png">



