### PR TITLE
version suggestion message for documentation

### DIFF
--- a/docs/src/scss/_colors.scss
+++ b/docs/src/scss/_colors.scss
@@ -39,3 +39,4 @@ $ifm-color-success: rgba(77, 191, 77, 0.3);
 $ifm-color-info: rgba(135, 215, 242, 0.3);
 $ifm-color-warning: rgba(255, 208, 77, 0.3);
 $collapse-button-bg-color-dark: #2e333a;
+$ifm-alert-color: $blue-500;

--- a/docs/src/scss/custom.scss
+++ b/docs/src/scss/custom.scss
@@ -42,6 +42,7 @@
   --ifm-alert-border-radius: 0;
   --ifm-alert-padding-vertical: 1.5rem;
   --ifm-alert-padding-horizontal: 0.75rem;
+  --ifm-alert-color: $ifm-alert-color;
   --ifm-color-danger: #{$ifm-color-danger};
   --ifm-color-success: #{$ifm-color-success};
   --ifm-color-info: #{$ifm-color-info};

--- a/docs/src/theme/DocItem/index.js
+++ b/docs/src/theme/DocItem/index.js
@@ -16,6 +16,7 @@ import {
   useActiveVersion,
 } from "@theme/hooks/useDocs";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import DocVersionSuggestions from '@theme/DocVersionSuggestions';
 import Search from "@theme/SearchBar";
 import EditThisPage from "@theme/GitEditThisPage";
 import { VersionDropdown } from "@site/src/components/VersionDropdown";
@@ -91,6 +92,8 @@ function DocItem(props) {
                 <Search />
                 {(width < breakpoints?.sm) && <VersionDropdown />}
               </div>
+              {/* DocVersionSuggestions will show an alert on the page if the opened documentation is not the latest one  */}
+              <DocVersionSuggestions />
               <div className="markdown">
                 <DocContent />
               </div>


### PR DESCRIPTION
This PR will enable the document version suggestion, if the opened documentation is not the latest one then an alert will show to the user that this document which is no longer actively maintained.



@IsAmrish  is working on this PR #110 , once this PR is merged i have to add the stylings for this PR. The current screenshot is docusaurus default.