### PR TITLE
Add Lazy loading feature to images

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2263,6 +2263,16 @@
       "integrity": "sha512-2d7TUhOQBG6cSVSSSWaoSu+Ds84VQFTuVKLeGNc2GtfA7JDr+z3ujl4n/rezaRRNEhjn+9SllwHy1iNxxP8jDg==",
       "dev": true
     },
+    "@types/react-lazy-load-image-component": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/react-lazy-load-image-component/-/react-lazy-load-image-component-1.5.1.tgz",
+      "integrity": "sha512-MvR5/20LXczHorci3Yuo3c8/iSHqpSw5MC5aYnEPwytCitm6rd/fz7GFjRCk9wjjGS9750IP6qSP87oU9G+lSA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "@types/react-router": {
       "version": "5.1.13",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.13.tgz",
@@ -9710,6 +9720,11 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -13420,6 +13435,15 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-lazy-load-image-component": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-lazy-load-image-component/-/react-lazy-load-image-component-1.5.1.tgz",
+      "integrity": "sha512-grTEZzURLHPkq7JoipcBBQU44ijdF4fH3Cb+eSD5eSAaMsjugbXqTaVWm5ruPUNLduoNR9KKQF6bOR9h2WphEg==",
+      "requires": {
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1"
+      }
     },
     "react-markdown": {
       "version": "6.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -24,7 +24,6 @@
     "react-github-btn": "^1.2.0",
     "react-gtm-module": "^2.0.11",
     "react-i18next": "^11.8.12",
-    "react-lazy-load-image-component": "^1.5.1",
     "react-markdown": "^6.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -24,6 +24,7 @@
     "react-github-btn": "^1.2.0",
     "react-gtm-module": "^2.0.11",
     "react-i18next": "^11.8.12",
+    "react-lazy-load-image-component": "^1.5.1",
     "react-markdown": "^6.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
@@ -59,6 +60,7 @@
   },
   "devDependencies": {
     "@types/react-gtm-module": "^2.0.0",
+    "@types/react-lazy-load-image-component": "^1.5.1",
     "@types/react-slick": "^0.23.4"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -24,6 +24,7 @@
     "react-github-btn": "^1.2.0",
     "react-gtm-module": "^2.0.11",
     "react-i18next": "^11.8.12",
+    "react-lazy-load-image-component": "^1.5.1",
     "react-markdown": "^6.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/website/src/components/BlogsSlider/index.tsx
+++ b/website/src/components/BlogsSlider/index.tsx
@@ -31,6 +31,7 @@ const BlogsSlider: React.FC<BlogsSliderProps> = ({recommendedBlogs}) => {
         onClick={onClick}
       >
         <img
+          loading="lazy"
           src="../Images/svg/right_arrow.svg"
           alt={t("home.adaptorsTestimonials.nextArrowAlt")}
         />
@@ -47,6 +48,7 @@ const BlogsSlider: React.FC<BlogsSliderProps> = ({recommendedBlogs}) => {
         onClick={onClick}
       >
         <img
+          loading="lazy"
           src="../Images/svg/left_arrow.svg"
           alt={t("home.adaptorsTestimonials.previousArrowAlt")}
         />

--- a/website/src/components/DisplayAuthorandReadTime/index.tsx
+++ b/website/src/components/DisplayAuthorandReadTime/index.tsx
@@ -41,6 +41,7 @@ const DisplayAuthorandReadTime: React.FC<displayAuthorandReadTimeProps> = ({
           </span>
           <p className={classes.readTime}>
             <img
+              loading="lazy"
               src="../Images/svg/time-five.svg"
               alt={t("header.submitAlt")}
               className={classes.rightSpacing}

--- a/website/src/components/EventSlider/index.tsx
+++ b/website/src/components/EventSlider/index.tsx
@@ -17,6 +17,7 @@ const EventSlider: React.FC = () => {
         onClick={onClick}
       >
         <img
+          loading="lazy"
           src="../Images/svg/right_arrow.svg"
           alt={t("community.communityEvents.nextArrowAlt")}
         />
@@ -32,6 +33,7 @@ const EventSlider: React.FC = () => {
         onClick={onClick}
       >
         <img
+          loading="lazy"
           src="../Images/svg/left_arrow.svg"
           alt={t("community.communityEvents.previousArrowAlt")}
         />
@@ -107,7 +109,7 @@ const EventSlider: React.FC = () => {
                   <Link className={classes.linkText} href={event.buttonLink} target="_blank">
                     <Box display="flex">
                       {event.buttonText ? event.buttonText : t('community.communityEvents.clickHere')}
-                      <img src="../Images/svg/arrow_orange.svg" alt="" />
+                      <img loading="lazy" src="../Images/svg/arrow_orange.svg" alt="" />
                     </Box>
                   </Link>
                 </Box>

--- a/website/src/components/Footer/index.tsx
+++ b/website/src/components/Footer/index.tsx
@@ -25,7 +25,7 @@ const Footer: React.FC = () => {
     // const [disableContinueButton, setDisableContinueButton] = useState<boolean>(true);
 
     const openEBSLogo = (
-        <img src="../Images/logos/logo.svg" className={classes.logo} alt={t('generic.openEBS')}></img>
+        <img loading="lazy" src="../Images/logos/logo.svg" className={classes.logo} alt={t('generic.openEBS')}></img>
     );
 
     // useEffect(() => {
@@ -45,7 +45,7 @@ const Footer: React.FC = () => {
                 {socialLinks.map(({ label, href, imgURL }) => {
                     return (   
                         <Link href={href} target="_blank" className={classes.socialIconButton} key={label}>
-                            <img src={imgURL} alt={label}/>
+                            <img loading="lazy" src={imgURL} alt={label}/>
                         </Link>
                     );
                 })}
@@ -198,7 +198,7 @@ const Footer: React.FC = () => {
                             </div>
                             <div>
                                 <Link className={classes.contributeButton}>
-                                    <img src="../Images/logos/githubLogo.svg" className={classes.githubMobileIcon} alt={t('generic.github')}></img> 
+                                    <img loading="lazy" src="../Images/logos/githubLogo.svg" className={classes.githubMobileIcon} alt={t('generic.github')}></img> 
                                     {t('footer.contribute')}
                                 </Link>
                             </div>

--- a/website/src/components/Header/index.tsx
+++ b/website/src/components/Header/index.tsx
@@ -24,7 +24,7 @@ const Header: React.FC = () => {
     const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
 
     const openEBSLogo = (
-        <img src="../Images/logos/logo.svg" className={classes.logo} alt={t('generic.openEBS')}></img>
+        <img loading="lazy" src="../Images/logos/logo.svg" className={classes.logo} alt={t('generic.openEBS')}></img>
     );
 
     var currentPathName = useLocation().pathname;
@@ -34,10 +34,10 @@ const Header: React.FC = () => {
           return (
               <div className={classes.socialIconsWrapper}>
                     <Link href={EXTERNAL_LINKS.OPENEBS_GITHUB_REPO}>
-                        <img src="../Images/logos/githubLogo.svg" className={classes.socialIcon} alt={t('generic.github')}></img>
+                        <img loading="lazy" src="../Images/logos/githubLogo.svg" className={classes.socialIcon} alt={t('generic.github')}></img>
                     </Link>
                     <Link href="/community">
-                        <img src="../Images/logos/slackLogo.svg" className={classes.socialIcon} alt={t('generic.slack')}></img>
+                        <img loading="lazy" src="../Images/logos/slackLogo.svg" className={classes.socialIcon} alt={t('generic.slack')}></img>
                     </Link>
               </div>
           );
@@ -79,7 +79,7 @@ const Header: React.FC = () => {
                         onClick: handleDrawerOpen,
                     }}
                     >
-                    <img src="../Images/svg/hamburger.svg" alt={t('header.menuAlt')}></img>
+                    <img loading="lazy" src="../Images/svg/hamburger.svg" alt={t('header.menuAlt')}></img>
                     </IconButton>
                 </div>
                 <Drawer elevation={0}
@@ -92,7 +92,7 @@ const Header: React.FC = () => {
                     <div className={classes.drawerPaper}>
                         <div className={classes.closeIcon}>
                             <IconButton aria-label="close drawer" onClick={() => handleDrawerClose()}>
-                                <img src="../Images/svg/x-circle.svg" alt={t('header.closeMenuAlt')}></img>
+                                <img loading="lazy" src="../Images/svg/x-circle.svg" alt={t('header.closeMenuAlt')}></img>
                             </IconButton>
                         </div>
                         <div className={classes.mobileNavWrapper}>

--- a/website/src/components/JoinCommunity/index.tsx
+++ b/website/src/components/JoinCommunity/index.tsx
@@ -45,11 +45,11 @@ const JoinCommunity: React.FC = () => {
                 <Grid item sm={6} xs={12}>
                     <Paper className={[classes.paper, classes.leftPaper, slackFlip ? classes.flip : ''].join(' ')} onClick={()=> handleSlackFlip()}>
                         <div className={classes.front}>
-                            <img src="../Images/logos/slack_full.svg" alt={t('joinCommunity.slackAlt')}></img>
+                            <img loading="lazy" src="../Images/logos/slack_full.svg" alt={t('joinCommunity.slackAlt')}></img>
                         </div>
                         <div className={classes.back}>
                             <div className={classes.flippedCard}>
-                                <img src="../Images/logos/slack_full.svg" alt={t('joinCommunity.slackAlt')} className={classes.flippedLogo}></img>
+                                <img loading="lazy" src="../Images/logos/slack_full.svg" alt={t('joinCommunity.slackAlt')} className={classes.flippedLogo}></img>
                                 <Typography variant='h4' className={classes.cardTitle}>
                                     {t('joinCommunity.slackTitle')}
                                 </Typography>
@@ -71,7 +71,7 @@ const JoinCommunity: React.FC = () => {
                                         }}
                                         />
                                         <IconButton aria-label="submit" className={classes.iconButton} disabled={disableContinueButton} type="submit">
-                                            <img src="../Images/svg/arrow_orange.svg" alt={t('joinCommunity.submitAlt')}/>
+                                            <img loading="lazy" src="../Images/svg/arrow_orange.svg" alt={t('joinCommunity.submitAlt')}/>
                                         </IconButton>
                                     </div>
                                 </form>
@@ -82,11 +82,11 @@ const JoinCommunity: React.FC = () => {
                 <Grid item sm={6} xs={12}>
                     <Paper className={[classes.paper, classes.rightPaper, gitHubFlip ? classes.flip : ''].join(' ')} onClick={()=> handleGitHubFlip()}>
                         <div className={classes.front}>
-                            <img src="../Images/logos/github_full.svg" alt={t('joinCommunity.gitHubAlt')}></img>
+                            <img loading="lazy" src="../Images/logos/github_full.svg" alt={t('joinCommunity.gitHubAlt')}></img>
                         </div>
                         <div className={classes.back}>
                             <div className={classes.flippedCard}>
-                                <img src="../Images/logos/github_full_small.svg" alt={t('joinCommunity.gitHubAlt')} className={classes.flippedLogo}></img>
+                                <img loading="lazy" src="../Images/logos/github_full_small.svg" alt={t('joinCommunity.gitHubAlt')} className={classes.flippedLogo}></img>
                                 <Typography variant='h4' className={classes.cardTitle}>
                                     {t('joinCommunity.gitHubTitle')}
                                 </Typography>

--- a/website/src/components/MiniBlog/index.tsx
+++ b/website/src/components/MiniBlog/index.tsx
@@ -55,6 +55,7 @@ const MiniBlog: React.FC = () => {
         onClick={onClick}
       >
         <img
+          loading="lazy"
           src="../Images/svg/right_arrow.svg"
           alt={t("home.adaptorsTestimonials.nextArrowAlt")}
         />
@@ -71,6 +72,7 @@ const MiniBlog: React.FC = () => {
         onClick={onClick}
       >
         <img
+          loading="lazy"
           src="../Images/svg/left_arrow.svg"
           alt={t("home.adaptorsTestimonials.previousArrowAlt")}
         />

--- a/website/src/components/Sponsor/index.tsx
+++ b/website/src/components/Sponsor/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import useStyles from "./styles";
 import { useTranslation } from "react-i18next";
 import { Grid, Typography } from "@material-ui/core";
+import { LazyLoadImage } from "react-lazy-load-image-component";
+import 'react-lazy-load-image-component/src/effects/blur.css';
 
 const Sponsor: React.FC = () => {
   const classes = useStyles();
@@ -11,7 +13,7 @@ const Sponsor: React.FC = () => {
     <div className={classes.root}>
       <Grid container justify="space-evenly" alignItems="center">
         <Grid item xs={12} md={4}>
-          <img
+        <LazyLoadImage effect="blur"
             src="../Images/svg/sponsor_mule.svg"
             alt={t("newsletter.email")}
             className={classes.sponsorCompany}
@@ -19,7 +21,7 @@ const Sponsor: React.FC = () => {
         </Grid>
         <Grid item xs={12} md={4}>
           <Typography>{t("sponsors.mayadata")}</Typography>
-          <img
+          <LazyLoadImage effect="blur"
             src="../Images/logos/mayadata_logo.svg"
             alt={t("newsletter.email")}
             className={classes.sponsorCompany}
@@ -27,7 +29,7 @@ const Sponsor: React.FC = () => {
         </Grid>
         <Grid item xs={12} md={4}>
           <Typography>{t("sponsors.cncf")}</Typography>
-          <img
+          <LazyLoadImage effect="blur"
             src="../Images/logos/cncf_logo.svg"
             alt={t("newsletter.email")}
             className={classes.sponsorCompany}

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -235,6 +235,7 @@ const Blog: React.FC = () => {
                               >
                                 {t("blog.read")}
                                 <img
+                                  loading="lazy"
                                   src="../Images/svg/arrow_orange.svg"
                                   alt={t("header.submitAlt")}
                                   className={classes.arrow}
@@ -344,6 +345,7 @@ const Blog: React.FC = () => {
                               >
                                 {t("blog.read")}
                                 <img
+                                  loading="lazy"
                                   src="../Images/svg/arrow_orange.svg"
                                   alt={t("header.submitAlt")}
                                   className={classes.arrow}

--- a/website/src/pages/BlogPage/index.tsx
+++ b/website/src/pages/BlogPage/index.tsx
@@ -138,7 +138,7 @@ const BlogPage: React.FC = () => {
                   
                     <div className={classes.author}>
                       <div className={classes.authorImgWrapper}>
-                        <img src={`../Images/blog/authors/${currentBlogDetails?.author.toLowerCase()
+                        <img loading="lazy" src={`../Images/blog/authors/${currentBlogDetails?.author.toLowerCase()
                                     .replace(/[^\w ]+/g,'')
                                     .replace(/ +/g,'-')}.png`} className={classes.authorImg} alt={currentBlogDetails?.author}></img>
                       </div>
@@ -158,7 +158,7 @@ const BlogPage: React.FC = () => {
                                   <div className={["addthis_inline_share_toolbox", classes.socialIconButton].join(' ')} key={label}></div>
                                   :
                                   <Link className={classes.socialIconButton} key={label} onClick={(() => handleSocialSharing(label))}>
-                                      <img src={imgURL} alt={label}/>
+                                      <img loading="lazy" src={imgURL} alt={label}/>
                                   </Link>
                               );
                           })}
@@ -170,7 +170,7 @@ const BlogPage: React.FC = () => {
             </div>
 
             <div className={classes.blogBody}>
-              <img src={`/Images/blog/${queryBlogName}.png`} alt={currentBlogDetails?.title} className={classes.blogImg}></img>
+              <img loading="lazy" src={`/Images/blog/${queryBlogName}.png`} alt={currentBlogDetails?.title} className={classes.blogImg}></img>
               <ReactMarkdown children={currentBlogDetails?.content} />
             </div>
             
@@ -192,7 +192,7 @@ const BlogPage: React.FC = () => {
                           <div className={["addthis_inline_share_toolbox", classes.socialIconButton].join(' ')} key={label}></div>
                           :
                           <Link className={classes.socialIconButton} key={label} onClick={(() => handleSocialSharing(label))}>
-                              <img src={imgURL} alt={label}/>
+                              <img loading="lazy" src={imgURL} alt={label}/>
                           </Link>
                       );
                   })}
@@ -205,7 +205,7 @@ const BlogPage: React.FC = () => {
                 {width < mobileBreakpoint ?
                 <Button
                   className={classes.arrowButton}
-                  endIcon={<img src="../Images/svg/right_arrow.svg" alt={t('home.adaptorsTestimonials.previousArrowAlt')} />}
+                  endIcon={<img loading="lazy" src="../Images/svg/right_arrow.svg" alt={t('home.adaptorsTestimonials.previousArrowAlt')} />}
                   onClick={() => window.location.assign(`/blog/${previousBlog.slug}`) }
               >
                 {t('blog.previousArticle')}
@@ -213,7 +213,7 @@ const BlogPage: React.FC = () => {
               : 
               <Button
                   className={classes.arrowButton}
-                  startIcon={<img src="../Images/svg/left_arrow.svg" alt={t('home.adaptorsTestimonials.previousArrowAlt')} />}
+                  startIcon={<img loading="lazy" src="../Images/svg/left_arrow.svg" alt={t('home.adaptorsTestimonials.previousArrowAlt')} />}
                   onClick={() => window.location.assign(`/blog/${previousBlog.slug}`) }
               >
                 {t('blog.previousArticle')}
@@ -227,7 +227,7 @@ const BlogPage: React.FC = () => {
               <div className={classes.rightArrowButtonWrapper}>
                   <Button
                     className={classes.arrowButton}
-                    endIcon={<img src="../Images/svg/right_arrow.svg" alt={t('home.adaptorsTestimonials.nextArrowAlt')} />}
+                    endIcon={<img loading="lazy" src="../Images/svg/right_arrow.svg" alt={t('home.adaptorsTestimonials.nextArrowAlt')} />}
                     onClick={() => window.location.assign(`/blog/${nextBlog.slug}`) }
                   >
                     {t('blog.nextArticle')}

--- a/website/src/pages/CommercialSupport/index.tsx
+++ b/website/src/pages/CommercialSupport/index.tsx
@@ -15,6 +15,8 @@ import Newsletter from "../../components/Newsletter";
 import { VIEW_PORT } from "../../constants";
 import { useViewport } from "../../hooks/viewportWidth";
 import Sponsor from "../../components/Sponsor";
+import { LazyLoadImage } from "react-lazy-load-image-component";
+import "react-lazy-load-image-component/src/effects/blur.css";
 
 const Support: React.FC = () => {
   const { t } = useTranslation();
@@ -25,45 +27,63 @@ const Support: React.FC = () => {
   return (
     <div className={classes.root}>
       <div className={classes.introSection}>
-      <div className={classes.sectionDiv}>
-        {/* Commercial support intro section  */}
-        {!(width < mobileBreakpoint) ? (
-          /* Commercial support Desktop view  */
-          <Grid container direction="row" justify="center" alignItems="center">
-            <Grid item xs={12} sm={6}>
-              <Typography variant="h1" className={classes.pageHeader}>
-                {t("commercialSupport.title")}
-              </Typography>
-              <Typography className={classes.supportDescription}>{t("commercialSupport.description")}</Typography>
+        <div className={classes.sectionDiv}>
+          {/* Commercial support intro section  */}
+          {!(width < mobileBreakpoint) ? (
+            /* Commercial support Desktop view  */
+            <Grid
+              container
+              direction="row"
+              justify="center"
+              alignItems="center"
+            >
+              <Grid item xs={12} sm={6}>
+                <Typography variant="h1" className={classes.pageHeader}>
+                  {t("commercialSupport.title")}
+                </Typography>
+                <Typography className={classes.supportDescription}>
+                  {t("commercialSupport.description")}
+                </Typography>
+              </Grid>
+              <Grid item xs={12} sm={6} className={classes.supportImage}>
+                <span className={classes.introImage}>
+                  <LazyLoadImage
+                    effect="blur"
+                    src="/Images/png/support_mule.png"
+                    alt={t("commercialSupport.mule")}
+                  />
+                </span>
+              </Grid>
             </Grid>
-            <Grid item xs={12} sm={6} className={classes.supportImage}>
-              <img
-                src="/Images/png/support_mule.png"
-                alt={t("commercialSupport.mule")}
-                className={classes.introImage}
-              />
+          ) : (
+            /* Commercial support mobile view  */
+            <Grid
+              container
+              direction="row"
+              justify="center"
+              alignItems="center"
+            >
+              <Grid item xs={12}>
+                <Typography variant="h1" className={classes.pageHeader}>
+                  {t("commercialSupport.title")}
+                </Typography>
+              </Grid>
+              <Grid item xs={12} className={classes.supportImage}>
+                <span className={classes.introImage}>
+                  <LazyLoadImage
+                    effect="blur"
+                    src="/Images/png/support_mule.png"
+                    alt={t("commercialSupport.mule")}
+                  />
+                </span>
+              </Grid>
+              <Grid item xs={12}>
+                <Typography className={classes.supportDescription}>
+                  {t("commercialSupport.description")}
+                </Typography>
+              </Grid>
             </Grid>
-          </Grid>
-        ) : (
-          /* Commercial support mobile view  */
-          <Grid container direction="row" justify="center" alignItems="center">
-            <Grid item xs={12}>
-              <Typography variant="h1" className={classes.pageHeader}>
-                {t("commercialSupport.title")}
-              </Typography>
-            </Grid>
-            <Grid item xs={12} className={classes.supportImage}>
-              <img
-                src="/Images/png/support_mule.png"
-                alt="support-mule"
-                className={classes.introImage}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <Typography className={classes.supportDescription}>{t("commercialSupport.description")}</Typography>
-            </Grid>
-          </Grid>
-        )}
+          )}
         </div>
       </div>
 
@@ -85,6 +105,7 @@ const Support: React.FC = () => {
                   <Card className={classes.cardProps} key={elm.id}>
                     <CardContent>
                       <img
+                        loading="lazy"
                         src={elm.image}
                         alt={elm.name}
                         className={classes.cardImage}
@@ -108,6 +129,7 @@ const Support: React.FC = () => {
                         >
                           {t("commercialSupport.visitWebsite")}
                           <img
+                            loading="lazy"
                             src="../Images/svg/arrow_orange.svg"
                             alt={t("header.submitAlt")}
                             className={classes.arrow}

--- a/website/src/pages/Community/index.tsx
+++ b/website/src/pages/Community/index.tsx
@@ -6,8 +6,10 @@ import Footer from "../../components/Footer";
 import JoinCommunity from "../../components/JoinCommunity";
 import { EXTERNAL_LINKS, VIEW_PORT } from "../../constants";
 import { useViewport } from "../../hooks/viewportWidth";
-import EventSlider from '../../components/EventSlider';
-import events from '../../resources/events.json';
+import EventSlider from "../../components/EventSlider";
+import events from "../../resources/events.json";
+import { LazyLoadImage } from "react-lazy-load-image-component";
+import "react-lazy-load-image-component/src/effects/blur.css";
 
 const Community: React.FC = () => {
   const { t } = useTranslation();
@@ -41,160 +43,199 @@ const Community: React.FC = () => {
   return (
     <div className={classes.root}>
       <div className={classes.communityBackground}>
-      <div className={classes.sectionDiv}>
-        {/* Commercial support intro section  */}
-        {!(width < mobileBreakpoint) ? (
-          /* Commercial support Desktop view  */
-          <Grid container direction="row" justify="center" alignItems="center">
-            <Grid item xs={12} sm={6}>
-              <Typography variant="h1" className={classes.pageHeader}>
-                {t("community.title")}
-              </Typography>
-              <Typography className={classes.supportDescription}>{t("community.description")}</Typography>
+        <div className={classes.sectionDiv}>
+          {/* Commercial support intro section  */}
+          {!(width < mobileBreakpoint) ? (
+            /* Commercial support Desktop view  */
+            <Grid
+              container
+              direction="row"
+              justify="center"
+              alignItems="center"
+            >
+              <Grid item xs={12} sm={6}>
+                <Typography variant="h1" className={classes.pageHeader}>
+                  {t("community.title")}
+                </Typography>
+                <Typography className={classes.supportDescription}>
+                  {t("community.description")}
+                </Typography>
+              </Grid>
+              <Grid item xs={12} sm={6} className={classes.supportImage}>
+                <span className={classes.introImage}>
+                  <LazyLoadImage
+                    effect="blur"
+                    src="/Images/svg/community.svg"
+                    alt={t("community.mule")}
+                  />
+                </span>
+              </Grid>
             </Grid>
-            <Grid item xs={12} sm={6} className={classes.supportImage}>
-              <img
-                src="/Images/svg/community.svg"
-                alt={t("community.mule")}
-                className={classes.introImage}
-              />
+          ) : (
+            /* Commercial support mobile view  */
+            <Grid
+              container
+              direction="row"
+              justify="center"
+              alignItems="center"
+            >
+              <Grid item xs={12}>
+                <Typography variant="h1" className={classes.pageHeader}>
+                  {t("community.title")}
+                </Typography>
+              </Grid>
+              <Grid item xs={12} className={classes.supportImage}>
+                <span className={classes.introImage}>
+                  <LazyLoadImage
+                    effect="blur"
+                    src="/Images/svg/community.svg"
+                    alt={t("community.mule")}
+                  />
+                </span>
+              </Grid>
+              <Grid item xs={12}>
+                <Typography className={classes.supportDescription}>
+                  {t("community.description")}
+                </Typography>
+              </Grid>
             </Grid>
-          </Grid>
-        ) : (
-          /* Commercial support mobile view  */
-          <Grid container direction="row" justify="center" alignItems="center">
-            <Grid item xs={12}>
-              <Typography variant="h1" className={classes.pageHeader}>
-                {t("community.title")}
-              </Typography>
-            </Grid>
-            <Grid item xs={12} className={classes.supportImage}>
-              <img
-                src="/Images/svg/community.svg"
-                alt={t("community.mule")}
-                className={classes.introImage}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <Typography className={classes.supportDescription}>{t("community.description")}</Typography>
-            </Grid>
-          </Grid>
-        )}
-      </div>
+          )}
+        </div>
 
-      {/* Join our community section */}
-      <section>
-        <JoinCommunity />
-      </section>
+        {/* Join our community section */}
+        <section>
+          <JoinCommunity />
+        </section>
       </div>
       {/* Community events slider section */}
       <section>
-          <Typography variant="h2" className={classes.sectionTitle}>
-            {t("community.communityEvents.title")}
-          </Typography>
-          <div className={`${classes.sectionDiv} ${classes.sliderFullWidth}`}>
+        <Typography variant="h2" className={classes.sectionTitle}>
+          {t("community.communityEvents.title")}
+        </Typography>
+        <div className={`${classes.sectionDiv} ${classes.sliderFullWidth}`}>
           {events.length ? (
-                <EventSlider />
-            ) : (
-                <Typography variant="h4" className={classes.noEventText}>
-                    {t("community.communityEvents.noEvent.message")}
-                </Typography>
-            )}
-          </div>
+            <EventSlider />
+          ) : (
+            <Typography variant="h4" className={classes.noEventText}>
+              {t("community.communityEvents.noEvent.message")}
+            </Typography>
+          )}
+        </div>
       </section>
 
       {/* Contribution section */}
       <div className={classes.installationDiv}>
         <section>
           <div className={classes.sectionDiv}>
-          <Typography variant="h2" className={classes.sectionTitle}>
-            {t("contributing.title")}
-          </Typography>
-          <Grid container justify="space-between">
-            <Grid item lg={5} md={6} sm={12}>
-              <Paper className={classes.paper}>
-                <div className={classes.iconHolder}>
-                  <img
-                    src="../Images/svg/openebs_hacker.svg"
-                    alt={t("contributing.openEBSHackerTitle")}
-                  ></img>
-                </div>
-                <h3 className={classes.contributionSubTitle}>{t("contributing.openEBSHackerTitle")}</h3>
-                <Typography className={classes.description}>
-                  {t("contributing.openEBSHackerDescription")}
-                </Typography>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  size="small"
-                  className={classes.solidButton}
-                  onClick={() => { window.open(EXTERNAL_LINKS.CONTRIBUTE_LINK, '_blank') }}
-                >
-                  {t("community.contributeBtnLabel")}
-                </Button>
-              </Paper>
+            <Typography variant="h2" className={classes.sectionTitle}>
+              {t("contributing.title")}
+            </Typography>
+            <Grid container justify="space-between">
+              <Grid item lg={5} md={6} sm={12}>
+                <Paper className={classes.paper}>
+                  <div className={classes.iconHolder}>
+                    <img
+                      loading="lazy"
+                      src="../Images/svg/openebs_hacker.svg"
+                      alt={t("contributing.openEBSHackerTitle")}
+                    ></img>
+                  </div>
+                  <h3 className={classes.contributionSubTitle}>
+                    {t("contributing.openEBSHackerTitle")}
+                  </h3>
+                  <Typography className={classes.description}>
+                    {t("contributing.openEBSHackerDescription")}
+                  </Typography>
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    size="small"
+                    className={classes.solidButton}
+                    onClick={() => {
+                      window.open(EXTERNAL_LINKS.CONTRIBUTE_LINK, "_blank");
+                    }}
+                  >
+                    {t("community.contributeBtnLabel")}
+                  </Button>
+                </Paper>
+              </Grid>
+              <Grid item lg={5} md={6} sm={12}>
+                <Paper className={classes.paper}>
+                  <div className={classes.iconHolder}>
+                    <img
+                      loading="lazy"
+                      src="../Images/svg/governance.svg"
+                      alt={t("contributing.governanceTitle")}
+                    ></img>
+                  </div>
+                  <h3 className={classes.contributionSubTitle}>
+                    {t("contributing.governanceTitle")}
+                  </h3>
+                  <Typography className={classes.description}>
+                    {t("contributing.governanceDescription")}
+                  </Typography>
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    size="small"
+                    className={classes.solidButton}
+                    onClick={() => {
+                      window.open(EXTERNAL_LINKS.GOVERNANCE_LINK, "_blank");
+                    }}
+                  >
+                    {t("community.checkItOutBtnLabel")}
+                  </Button>
+                </Paper>
+              </Grid>
             </Grid>
-            <Grid item lg={5} md={6} sm={12}>
-              <Paper className={classes.paper}>
-                <div className={classes.iconHolder}>
-                  <img
-                    src="../Images/svg/governance.svg"
-                    alt={t("contributing.governanceTitle")}
-                  ></img>
-                </div>
-                <h3 className={classes.contributionSubTitle}>{t("contributing.governanceTitle")}</h3>
-                <Typography className={classes.description}>
-                  {t("contributing.governanceDescription")}
-                </Typography>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  size="small"
-                  className={classes.solidButton}
-                  onClick={() => { window.open(EXTERNAL_LINKS.GOVERNANCE_LINK, '_blank') }}
-                >
-                  {t("community.checkItOutBtnLabel")}
-                </Button>
-              </Paper>
-            </Grid>
-          </Grid>
           </div>
         </section>
 
         {/* Sponsor and Dependent Projects */}
         <div className={classes.sectionDiv}>
-          <Grid container justify="space-evenly" className={classes.sponsorAndDependentProjectsWrapper}>
+          <Grid
+            container
+            justify="space-evenly"
+            className={classes.sponsorAndDependentProjectsWrapper}
+          >
             <Grid item xs={12} md={5}>
               <div className={classes.sponsorAndDependentProjectsDiv}>
-                <Typography className={classes.sponsorAndDependentProjectsDescription}>
+                <Typography
+                  className={classes.sponsorAndDependentProjectsDescription}
+                >
                   {t("community.sponsor.mainSponsor")}
                 </Typography>
                 <img
+                  loading="lazy"
                   src="../Images/logos/mayadata_logo.svg"
                   alt={t("generic.mayadata")}
                   className={classes.mayaDataLogo}
                 />
               </div>
-              
             </Grid>
             <Grid item xs={12} md={7}>
-            <div className={classes.sponsorAndDependentProjectsDiv}>
-              <Typography className={classes.sponsorAndDependentProjectsDescription}>
-                {t("community.sponsor.dependentProjects")}
-              </Typography>
-              <div>
+              <div className={classes.sponsorAndDependentProjectsDiv}>
+                <Typography
+                  className={classes.sponsorAndDependentProjectsDescription}
+                >
+                  {t("community.sponsor.dependentProjects")}
+                </Typography>
+                <div>
                   {dependentProjects.map(({ label, image_src, alt }) => {
-                      return (
-                        <img
+                    return (
+                      <img
+                        loading="lazy"
                         src={image_src}
                         alt={alt}
-                        className={[classes.company, (label === 'rancher' ? classes.rancher : '')].join(' ')}
+                        className={[
+                          classes.company,
+                          label === "rancher" ? classes.rancher : "",
+                        ].join(" ")}
                       />
-                      );
+                    );
                   })}
+                </div>
               </div>
-              </div>
-              
             </Grid>
           </Grid>
         </div>

--- a/website/src/pages/Home/index.tsx
+++ b/website/src/pages/Home/index.tsx
@@ -24,6 +24,8 @@ import MiniBlog from '../../components/MiniBlog';
 import adopterData from "../../adopters.md";
 import EventSlider from '../../components/EventSlider';
 import events from '../../resources/events.json';
+import { LazyLoadImage } from 'react-lazy-load-image-component';
+import 'react-lazy-load-image-component/src/effects/blur.css';
 
 const Home: React.FC = () => {
     const classes = useStyles();
@@ -256,7 +258,7 @@ const Home: React.FC = () => {
             className={className}
             style={{ ...style, display: "block" }}
             onClick={onClick}
-          ><img src="../Images/svg/right_arrow.svg" alt={t('home.adaptorsTestimonials.nextArrowAlt')} /></div>
+          ><img loading="lazy" src="../Images/svg/right_arrow.svg" alt={t('home.adaptorsTestimonials.nextArrowAlt')} /></div>
         );
       }
       
@@ -267,7 +269,7 @@ const Home: React.FC = () => {
             className={className}
             style={{ ...style, display: "block" }}
             onClick={onClick}
-          ><img src="../Images/svg/left_arrow.svg" alt={t('home.adaptorsTestimonials.previousArrowAlt')} /></div>
+          ><img loading="lazy" src="../Images/svg/left_arrow.svg" alt={t('home.adaptorsTestimonials.previousArrowAlt')} /></div>
         );
     }
 
@@ -285,7 +287,7 @@ const Home: React.FC = () => {
                         </Grid>
                         <Grid item sm={4} xs={1}>
                             <Paper className={[classes.paper, classes.secondGrid].join(' ')}>
-                                <img src="../Images/png/homepage_main.png" alt={t('home.landingScreenImageAlt')} className={classes.landingImage}></img>
+                                <img loading="lazy" placeholder={"../Images/png/homepage_main.png?q=20"} src="../Images/png/homepage_main.png?q=20" alt={t('home.landingScreenImageAlt')} className={classes.landingImage}></img>
                             </Paper>
                         </Grid>
                         <Grid item xs={12}>
@@ -305,7 +307,7 @@ const Home: React.FC = () => {
                                         <Button
                                             variant="outlined"
                                             color="secondary"
-                                            endIcon={<img src="../Images/svg/play.svg" alt={t('home.openebs.watchDemo')}></img>}
+                                            endIcon={<img loading="lazy" src="../Images/svg/play.svg" alt={t('home.openebs.watchDemo')}></img>}
                                             className={classes.outlineButton}
                                             href={EXTERNAL_LINKS.OPENEBS_YOUTUBE_INTRO} target="_blank"
                                         >
@@ -327,14 +329,14 @@ const Home: React.FC = () => {
                                         <Button variant="contained" 
                                         color="secondary" 
                                         className={classes.solidButton}
-                                        endIcon={<img src="../Images/logos/slack_white.svg" alt={t('home.community.joinOnSlack')}></img>}
+                                        endIcon={<img loading="lazy" src="../Images/logos/slack_white.svg" alt={t('home.community.joinOnSlack')}></img>}
                                         href="/community">
                                             {t('home.community.joinOnSlack')}
                                         </Button>
                                         <Button
                                             variant="outlined"
                                             color="secondary"
-                                            endIcon={<img src="../Images/logos/github_orange.svg" alt={t('home.community.joinOnGitHub')}></img>}
+                                            endIcon={<img loading="lazy" src="../Images/logos/github_orange.svg" alt={t('home.community.joinOnGitHub')}></img>}
                                             className={classes.outlineButton}
                                             href={EXTERNAL_LINKS.OPENEBS_GITHUB_REPO} target="_blank"
                                         >
@@ -369,7 +371,7 @@ const Home: React.FC = () => {
                                         <Button
                                             variant="outlined"
                                             color="secondary"
-                                            endIcon={<img src="../Images/svg/play.svg" alt={t('home.openebs.watchDemo')}></img>}
+                                            endIcon={<img loading="lazy" src="../Images/svg/play.svg" alt={t('home.openebs.watchDemo')}></img>}
                                             href={EXTERNAL_LINKS.OPENEBS_YOUTUBE_INTRO} target="_blank"
                                         >
                                         {t('home.openebs.watchDemo')}
@@ -390,14 +392,14 @@ const Home: React.FC = () => {
                                         <Button variant="contained" 
                                         color="secondary" 
                                         className={classes.solidButton}
-                                        endIcon={<img src="../Images/logos/slack_white.svg" alt={t('home.community.joinOnSlack')}></img>}
+                                        endIcon={<img loading="lazy" src="../Images/logos/slack_white.svg" alt={t('home.community.joinOnSlack')}></img>}
                                         href="/community">
                                             {t('home.community.joinOnSlack')}
                                         </Button>
                                         <Button
                                             variant="outlined"
                                             color="secondary"
-                                            endIcon={<img src="../Images/logos/github_orange.svg" alt={t('home.community.joinOnGitHub')}></img>}
+                                            endIcon={<img loading="lazy" src="../Images/logos/github_orange.svg" alt={t('home.community.joinOnGitHub')}></img>}
                                             href={EXTERNAL_LINKS.OPENEBS_GITHUB_REPO} target="_blank"
                                         >
                                         {t('home.community.joinOnGitHub')}
@@ -407,7 +409,9 @@ const Home: React.FC = () => {
                             </Grid>
                             <Grid item lg={6} md={5} sm={4}>
                                 <Paper className={classes.paper}>
-                                    <img src="../Images/png/homepage_main.png" alt={t('home.landingScreenImageAlt')} className={classes.landingImage}></img>
+                                    <span className={classes.landingImage}>
+                                        <LazyLoadImage effect="blur" src={"../Images/png/homepage_main.png"} alt={t('home.landingScreenImageAlt')}  />                                 
+                                    </span>
                                 </Paper>
                             </Grid>
                         </Grid>
@@ -418,34 +422,34 @@ const Home: React.FC = () => {
             <section>
                 <Slider {...logoSliderSettings} className={classes.logoCarousel}>
                     <div>
-                        <img src="../Images/logos/bloomberg_blue.png" alt={t('home.usedInProductionBy.bloomberg')} />
+                        <img loading="lazy" src="../Images/logos/bloomberg_blue.png" alt={t('home.usedInProductionBy.bloomberg')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/arista_blue.png" alt={t('home.usedInProductionBy.arista')} />
+                        <img loading="lazy" src="../Images/logos/arista_blue.png" alt={t('home.usedInProductionBy.arista')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/orange_blue.png" alt={t('home.usedInProductionBy.orange')} />
+                        <img loading="lazy" src="../Images/logos/orange_blue.png" alt={t('home.usedInProductionBy.orange')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/optoro_blue.png" alt={t('home.usedInProductionBy.optoro')} />
+                        <img loading="lazy" src="../Images/logos/optoro_blue.png" alt={t('home.usedInProductionBy.optoro')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/comcast_blue.png" alt={t('home.usedInProductionBy.comcast')} />
+                        <img loading="lazy" src="../Images/logos/comcast_blue.png" alt={t('home.usedInProductionBy.comcast')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/bloomberg_blue.png" alt={t('home.usedInProductionBy.bloomberg')} />
+                        <img loading="lazy" src="../Images/logos/bloomberg_blue.png" alt={t('home.usedInProductionBy.bloomberg')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/arista_blue.png" alt={t('home.usedInProductionBy.arista')} />
+                        <img loading="lazy" src="../Images/logos/arista_blue.png" alt={t('home.usedInProductionBy.arista')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/orange_blue.png" alt={t('home.usedInProductionBy.orange')} />
+                        <img loading="lazy" src="../Images/logos/orange_blue.png" alt={t('home.usedInProductionBy.orange')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/optoro_blue.png" alt={t('home.usedInProductionBy.optoro')} />
+                        <img loading="lazy" src="../Images/logos/optoro_blue.png" alt={t('home.usedInProductionBy.optoro')} />
                     </div>
                     <div>
-                        <img src="../Images/logos/comcast_blue.png" alt={t('home.usedInProductionBy.comcast')} />
+                        <img loading="lazy" src="../Images/logos/comcast_blue.png" alt={t('home.usedInProductionBy.comcast')} />
                     </div>
                 </Slider>
             </section>
@@ -464,7 +468,7 @@ const Home: React.FC = () => {
                     <Grid item md={4} sm={6}>
                         <Paper className={[classes.paper, classes.iconTextContainer].join(' ')}>
                             <div className={classes.iconHolder}>
-                                <img src="../Images/svg/money_bag.svg" alt={t('home.whatsInItForYou.saveMoney')}></img>
+                                <img loading="lazy" src="../Images/svg/money_bag.svg" alt={t('home.whatsInItForYou.saveMoney')}></img>
                             </div>
                             <Typography className={classes.description}>
                                 {t('home.whatsInItForYou.saveMoney')}
@@ -474,7 +478,7 @@ const Home: React.FC = () => {
                     <Grid item md={4} sm={6}>
                         <Paper className={[classes.paper, classes.iconTextContainer].join(' ')}>
                             <div className={classes.iconHolder}>
-                                <img src="../Images/svg/box.svg" alt={t('home.whatsInItForYou.flexibility')}></img>
+                                <img loading="lazy" src="../Images/svg/box.svg" alt={t('home.whatsInItForYou.flexibility')}></img>
                             </div>
                             <Typography className={classes.description}>
                                 {t('home.whatsInItForYou.flexibility')}
@@ -484,7 +488,7 @@ const Home: React.FC = () => {
                     <Grid item md={4} sm={6}>
                         <Paper className={[classes.paper, classes.iconTextContainer].join(' ')}>
                             <div className={classes.iconHolder}>
-                                <img src="../Images/svg/wheel.svg" alt={t('home.whatsInItForYou.resilience')}></img>
+                                <img loading="lazy" src="../Images/svg/wheel.svg" alt={t('home.whatsInItForYou.resilience')}></img>
                             </div>
                             <Typography className={classes.description}>
                                 {t('home.whatsInItForYou.resilience')}
@@ -494,7 +498,7 @@ const Home: React.FC = () => {
                     <Grid item md={4} sm={6}>
                         <Paper className={[classes.paper, classes.iconTextContainer].join(' ')}>
                             <div className={classes.iconHolder}>
-                                <img src="../Images/svg/cloud.svg" alt={t('home.whatsInItForYou.restoreData')}></img>
+                                <img loading="lazy" src="../Images/svg/cloud.svg" alt={t('home.whatsInItForYou.restoreData')}></img>
                             </div>
                             <Typography className={classes.description}>
                                 {t('home.whatsInItForYou.restoreData')}
@@ -504,7 +508,7 @@ const Home: React.FC = () => {
                     <Grid item md={4} sm={6}>
                         <Paper className={[classes.paper, classes.iconTextContainer].join(' ')}>
                             <div className={classes.iconHolder}>
-                                <img src="../Images/svg/lock.svg" alt={t('home.whatsInItForYou.openSource')}></img>
+                                <img loading="lazy" src="../Images/svg/lock.svg" alt={t('home.whatsInItForYou.openSource')}></img>
                             </div>
                             <Typography className={classes.description}>
                                 {t('home.whatsInItForYou.openSource')}
@@ -514,7 +518,7 @@ const Home: React.FC = () => {
                     <Grid item md={4} sm={6}>
                         <Paper className={[classes.paper, classes.iconTextContainer].join(' ')}>
                             <div className={classes.iconHolder}>
-                                <img src="../Images/svg/settings.svg" alt={t('home.whatsInItForYou.granularControl')}></img>
+                                <img loading="lazy" src="../Images/svg/settings.svg" alt={t('home.whatsInItForYou.granularControl')}></img>
                             </div>
                             <Typography className={classes.description}>
                                 {t('home.whatsInItForYou.granularControl')}
@@ -539,7 +543,7 @@ const Home: React.FC = () => {
                         </Typography>
                         
                         <LightTooltip title={copyCommand.status}>
-                            <Link onClick={copyToClipboard}><img src="../Images/svg/copy.svg" alt={copyCommand.status}></img></Link>
+                            <Link onClick={copyToClipboard}><img loading="lazy" src="../Images/svg/copy.svg" alt={copyCommand.status}></img></Link>
                         </LightTooltip>
                         <hr className={classes.divider}/>
                     </div>
@@ -563,7 +567,7 @@ const Home: React.FC = () => {
                             <div className={classes.installationCodeWrapper}>
 
                                 <Paper className={[classes.paper, classes.desktopCommandWrapper].join(' ')}>
-                                    <img src="../Images/png/homepage_desktop.png" alt={t('home.installation.desktopImgAlt')} className={classes.desktopImage}></img>
+                                    <img loading="lazy" src="../Images/png/homepage_desktop.png" alt={t('home.installation.desktopImgAlt')} className={classes.desktopImage}></img>
                                     <div className={classes.installationProviderCommandWrapper}>
                                         <Typography className={classes.installationProvider}>
                                             {asciinemaTitle}
@@ -577,19 +581,19 @@ const Home: React.FC = () => {
                                     <Paper className={[classes.paper, classes.installationButtonsWrapper].join(' ')}>
                                         <Button variant="contained" 
                                             className={[classes.installationButton, classes.installationLeftButton, installationButtonStatus.Redis.status ? classes.installationButtonActive : ''].join(' ')}
-                                            startIcon={<img src={installationButtonStatus.Redis.status ? storageProviders.Redis.white_logo : storageProviders.Redis.logo} alt={t('home.installation.redis')}></img>}
+                                            startIcon={<img loading="lazy" src={installationButtonStatus.Redis.status ? storageProviders.Redis.white_logo : storageProviders.Redis.logo} alt={t('home.installation.redis')}></img>}
                                             onClick={() => displayProviderInstallation('Redis')}>
                                             {t('home.installation.redis')}
                                         </Button>
                                         <Button variant="contained" 
                                             className={[classes.installationButton, classes.installationLeftButton, installationButtonStatus.Minio.status ? classes.installationButtonActive : ''].join(' ')}
-                                            startIcon={<img src={installationButtonStatus.Minio.status ? storageProviders.Minio.white_logo :storageProviders.Minio.logo} alt={t('home.installation.minio')}></img>}
+                                            startIcon={<img loading="lazy" src={installationButtonStatus.Minio.status ? storageProviders.Minio.white_logo :storageProviders.Minio.logo} alt={t('home.installation.minio')}></img>}
                                             onClick={() => displayProviderInstallation('Minio')}>
                                             {t('home.installation.minio')}
                                         </Button>
                                         <Button variant="contained" 
                                             className={[classes.installationButton, classes.installationLeftButton, installationButtonStatus.Percona.status ? classes.installationButtonActive : ''].join(' ')}
-                                            startIcon={<img src={installationButtonStatus.Percona.status ? storageProviders.Percona.white_logo : storageProviders.Percona.logo} alt={t('home.installation.percona')}></img>}
+                                            startIcon={<img loading="lazy" src={installationButtonStatus.Percona.status ? storageProviders.Percona.white_logo : storageProviders.Percona.logo} alt={t('home.installation.percona')}></img>}
                                             onClick={() => displayProviderInstallation('Percona')}>
                                             {t('home.installation.percona')}
                                         </Button>
@@ -598,19 +602,19 @@ const Home: React.FC = () => {
                                     <Paper className={[classes.paper, classes.installationButtonsWrapper].join(' ')}>
                                         <Button variant="contained" 
                                             className={[classes.installationButton, classes.installationRightButton, installationButtonStatus.MongoDB.status ? classes.installationButtonActive : ''].join(' ')}
-                                            startIcon={<img src={installationButtonStatus.MongoDB.status ? storageProviders.MongoDB.white_logo : storageProviders.MongoDB.logo} alt={t('home.installation.mongodb')}></img>}
+                                            startIcon={<img loading="lazy" src={installationButtonStatus.MongoDB.status ? storageProviders.MongoDB.white_logo : storageProviders.MongoDB.logo} alt={t('home.installation.mongodb')}></img>}
                                             onClick={() => displayProviderInstallation('MongoDB')}>
                                             {t('home.installation.mongodb')}
                                         </Button>
                                         <Button variant="contained" 
                                             className={[classes.installationButton, classes.installationRightButton, installationButtonStatus.Prometheus.status ? classes.installationButtonActive : ''].join(' ')}
-                                            startIcon={<img src={installationButtonStatus.Prometheus.status ? storageProviders.Prometheus.white_logo : storageProviders.Prometheus.logo} alt={t('home.installation.prometheus')}></img>}
+                                            startIcon={<img loading="lazy" src={installationButtonStatus.Prometheus.status ? storageProviders.Prometheus.white_logo : storageProviders.Prometheus.logo} alt={t('home.installation.prometheus')}></img>}
                                             onClick={() => displayProviderInstallation('Prometheus')}>
                                             {t('home.installation.prometheus')}
                                         </Button>
                                         <Button variant="contained" 
                                             className={[classes.installationButton, classes.installationRightButton, installationButtonStatus.MySQL.status ? classes.installationButtonActive : ''].join(' ')}
-                                            startIcon={<img src={installationButtonStatus.MySQL.status ? storageProviders.MySQL.white_logo : storageProviders.MySQL.logo} alt={t('home.installation.mysql')}></img>}
+                                            startIcon={<img loading="lazy" src={installationButtonStatus.MySQL.status ? storageProviders.MySQL.white_logo : storageProviders.MySQL.logo} alt={t('home.installation.mysql')}></img>}
                                             onClick={() => displayProviderInstallation('MySQL')}>
                                             {t('home.installation.mysql')}
                                         </Button>
@@ -625,19 +629,19 @@ const Home: React.FC = () => {
                                 <Paper className={[classes.paper, classes.installationButtonsWrapper].join(' ')}>
                                     <Button variant="contained" 
                                         className={[classes.installationButton, classes.installationLeftButton, installationButtonStatus.Redis.status ? classes.installationButtonActive : ''].join(' ')}
-                                        startIcon={<img src={installationButtonStatus.Redis.status ? storageProviders.Redis.white_logo : storageProviders.Redis.logo} alt={t('home.installation.redis')}></img>}
+                                        startIcon={<img loading="lazy" src={installationButtonStatus.Redis.status ? storageProviders.Redis.white_logo : storageProviders.Redis.logo} alt={t('home.installation.redis')}></img>}
                                         onClick={() => displayProviderInstallation('Redis')}>
                                         {t('home.installation.redis')}
                                     </Button>
                                     <Button variant="contained" 
                                         className={[classes.installationButton, classes.installationLeftButton, installationButtonStatus.Minio.status ? classes.installationButtonActive : ''].join(' ')}
-                                        startIcon={<img src={installationButtonStatus.Minio.status ? storageProviders.Minio.white_logo :storageProviders.Minio.logo} alt={t('home.installation.minio')}></img>}
+                                        startIcon={<img loading="lazy" src={installationButtonStatus.Minio.status ? storageProviders.Minio.white_logo :storageProviders.Minio.logo} alt={t('home.installation.minio')}></img>}
                                         onClick={() => displayProviderInstallation('Minio')}>
                                         {t('home.installation.minio')}
                                     </Button>
                                     <Button variant="contained" 
                                         className={[classes.installationButton, classes.installationLeftButton, installationButtonStatus.Percona.status ? classes.installationButtonActive : ''].join(' ')}
-                                        startIcon={<img src={installationButtonStatus.Percona.status ? storageProviders.Percona.white_logo : storageProviders.Percona.logo} alt={t('home.installation.percona')}></img>}
+                                        startIcon={<img loading="lazy" src={installationButtonStatus.Percona.status ? storageProviders.Percona.white_logo : storageProviders.Percona.logo} alt={t('home.installation.percona')}></img>}
                                         onClick={() => displayProviderInstallation('Percona')}>
                                         {t('home.installation.percona')}
                                     </Button>
@@ -645,7 +649,7 @@ const Home: React.FC = () => {
                             
                             
                                 <Paper className={[classes.paper, classes.desktopCommandWrapper].join(' ')}>
-                                    <img src="../Images/png/homepage_desktop.png" alt={t('home.installation.desktopImgAlt')} className={classes.desktopImage}></img>
+                                    <img loading="lazy" src="../Images/png/homepage_desktop.png" alt={t('home.installation.desktopImgAlt')} className={classes.desktopImage}></img>
                                     <div className={classes.installationProviderCommandWrapper}>
                                         <Typography className={classes.installationProvider}>
                                             {asciinemaTitle}
@@ -658,19 +662,19 @@ const Home: React.FC = () => {
                                 <Paper className={[classes.paper, classes.installationButtonsWrapper].join(' ')}>
                                     <Button variant="contained" 
                                         className={[classes.installationButton, classes.installationRightButton, installationButtonStatus.MongoDB.status ? classes.installationButtonActive : ''].join(' ')}
-                                        startIcon={<img src={installationButtonStatus.MongoDB.status ? storageProviders.MongoDB.white_logo : storageProviders.MongoDB.logo} alt={t('home.installation.mongodb')}></img>}
+                                        startIcon={<img loading="lazy" src={installationButtonStatus.MongoDB.status ? storageProviders.MongoDB.white_logo : storageProviders.MongoDB.logo} alt={t('home.installation.mongodb')}></img>}
                                         onClick={() => displayProviderInstallation('MongoDB')}>
                                         {t('home.installation.mongodb')}
                                     </Button>
                                     <Button variant="contained" 
                                         className={[classes.installationButton, classes.installationRightButton, installationButtonStatus.Prometheus.status ? classes.installationButtonActive : ''].join(' ')}
-                                        startIcon={<img src={installationButtonStatus.Prometheus.status ? storageProviders.Prometheus.white_logo : storageProviders.Prometheus.logo} alt={t('home.installation.prometheus')}></img>}
+                                        startIcon={<img loading="lazy" src={installationButtonStatus.Prometheus.status ? storageProviders.Prometheus.white_logo : storageProviders.Prometheus.logo} alt={t('home.installation.prometheus')}></img>}
                                         onClick={() => displayProviderInstallation('Prometheus')}>
                                         {t('home.installation.prometheus')}
                                     </Button>
                                     <Button variant="contained" 
                                         className={[classes.installationButton, classes.installationRightButton, installationButtonStatus.MySQL.status ? classes.installationButtonActive : ''].join(' ')}
-                                        startIcon={<img src={installationButtonStatus.MySQL.status ? storageProviders.MySQL.white_logo : storageProviders.MySQL.logo} alt={t('home.installation.mysql')}></img>}
+                                        startIcon={<img loading="lazy" src={installationButtonStatus.MySQL.status ? storageProviders.MySQL.white_logo : storageProviders.MySQL.logo} alt={t('home.installation.mysql')}></img>}
                                         onClick={() => displayProviderInstallation('MySQL')}>
                                         {t('home.installation.mysql')}
                                     </Button>
@@ -693,7 +697,7 @@ const Home: React.FC = () => {
                     </Typography>
                     <Grid container spacing={3} className={events.length ? '' : classes.noEvents}>
                         <Grid item xs={12} sm={4} className={classes.imageFluid}>
-                            <img src="../Images/svg/community.svg" alt={t("community.communityEvents.communityImageAlt")} />
+                            <LazyLoadImage effect="blur" loading="lazy" src="../Images/svg/community.svg" alt={t("community.communityEvents.communityImageAlt")} />
                         </Grid>
                         {events.length ? (
                             <Grid item xs={12} sm={8}>
@@ -711,7 +715,7 @@ const Home: React.FC = () => {
                 {isMobileView && 
                     <Grid item xs={12} className={classes.testimonialMuleWrapper}>
                         <Paper className={[classes.paper, classes.testimonialMule].join(' ')}>
-                            <img src="../Images/png/testimonials_mule.png" alt=""></img>
+                            <LazyLoadImage effect="blur" loading="lazy" src="../Images/png/testimonials_mule.png" alt="" />
                         </Paper>
                     </Grid>
                 }
@@ -773,7 +777,7 @@ const Home: React.FC = () => {
                     {!isMobileView && 
                         <Grid item sm={5} className={classes.testimonialMuleWrapper}>
                             <Paper className={[classes.paper, classes.testimonialMule].join(' ')}>
-                                <img src="../Images/png/testimonials_mule.png" alt=""></img>
+                                <LazyLoadImage effect="blur" src="../Images/png/testimonials_mule.png" alt="" />
                             </Paper>
                         </Grid>
                     }
@@ -804,7 +808,9 @@ const Home: React.FC = () => {
                     <Grid container spacing={3}>
                         <Grid item lg={4} md={4} sm={12}>
                             <Paper className={[classes.paper, classes.flyingMuleWrapper].join(' ')}>
-                                <img src="../Images/png/flying_mule.png" alt={t('home.youAreReadyToStart.flyingMuleAlt')} className={classes.flyingMule}></img>
+                                <span className={classes.flyingMule}>
+                                    <LazyLoadImage effect="blur" src="../Images/png/flying_mule.png" alt={t('home.youAreReadyToStart.flyingMuleAlt')} />
+                                </span>
                             </Paper>
                         </Grid>
                         <Grid item lg={5} md={4} sm={6}>
@@ -815,7 +821,7 @@ const Home: React.FC = () => {
                                     </Typography>
                                     
                                     <LightTooltip title={copyCommand.status}>
-                                        <Link onClick={copyToClipboard}><img src="../Images/svg/copy_orange.svg" alt=""></img></Link>
+                                        <Link onClick={copyToClipboard}><img loading="lazy" src="../Images/svg/copy_orange.svg" alt=""></img></Link>
                                     </LightTooltip>
                                     <hr className={[classes.divider, classes.codeTextHalfWidthUnderline].join(' ')}/>
 


### PR DESCRIPTION
Signed-off-by: AVRahul <a.v.rahul11@gmail.com>

- Add lazy loading functionality to all the images.
- Reduce the network all, request, and load images on demand.
- Implementation add an attribute `loading="lazy"` to all the <img> tags.
- Add library `react-lazy-load-image-component` to achieve a shimmer effect on the large images.
- With the library load images only when a user is on that viewport.
- Both the feature will help in improving the website performance.

links for refrence: 
https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading
https://www.npmjs.com/package/react-lazy-load-image-component