### PR TITLE
Fix `gap` property related issue

### DIFF
--- a/website/src/components/BlogsSlider/index.tsx
+++ b/website/src/components/BlogsSlider/index.tsx
@@ -45,7 +45,13 @@ const BlogsSlider: React.FC<BlogsSliderProps> = ({ recommendedBlogs }) => {
   }
 
   const getTags = (tags: Array<string>) => {
-    const tagItems = tags.map((tag) => <CustomTag blogLabel={tag} key={tag} />);
+    const tagItems = tags.map((tag) => {
+      return(
+        <div className={classes.tag}>
+          <CustomTag blogLabel={tag} key={tag} />
+        </div>
+      )
+    });
     return tagItems;
   };
 

--- a/website/src/components/BlogsSlider/index.tsx
+++ b/website/src/components/BlogsSlider/index.tsx
@@ -47,8 +47,8 @@ const BlogsSlider: React.FC<BlogsSliderProps> = ({ recommendedBlogs }) => {
   const getTags = (tags: Array<string>) => {
     const tagItems = tags.map((tag) => {
       return(
-        <div className={classes.tag}>
-          <CustomTag blogLabel={tag} key={tag} />
+        <div className={classes.tag} key={tag}>
+          <CustomTag blogLabel={tag} />
         </div>
       )
     });

--- a/website/src/components/BlogsSlider/style.ts
+++ b/website/src/components/BlogsSlider/style.ts
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   tagsWrapper: {
     display: 'flex',
     overflow: "scroll",
-    paddingBottom: '6px',
+    paddingBottom: theme.spacing(0.75),
   },
   tag: {
     marginRight: theme.spacing(1)

--- a/website/src/components/BlogsSlider/style.ts
+++ b/website/src/components/BlogsSlider/style.ts
@@ -14,10 +14,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tagsWrapper: {
     display: 'flex',
-    gap: '12px',
     overflow: "scroll",
-    paddingBottom: '2px',
+    paddingBottom: '6px',
   },
+  tag: {
+    marginRight: theme.spacing(1)
+  },
+
   title: {
     fontSize: 22,
     fontWeight: 700,

--- a/website/src/components/CustomTag/index.tsx
+++ b/website/src/components/CustomTag/index.tsx
@@ -44,7 +44,7 @@ const CustomTag: React.FC<blogTitleProps> = ({ blogLabel }) => {
 
   return (
     <>
-       <Typography variant="h6" className={classes.tag} style = {getTabStyle()}>
+       <Typography variant="h6" className={classes.tag} style={getTabStyle()}>
         <ReactMarkdown children={blogLabel} />
       </Typography>
     </>

--- a/website/src/components/Header/style.ts
+++ b/website/src/components/Header/style.ts
@@ -63,7 +63,8 @@ const useStyles = makeStyles((theme) => ({
         fontWeight: 700
     },
     socialIconsWrapper: {
-        display: 'flex',
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
         [theme.breakpoints.up('xs')]: {
             gap: theme.spacing(2),
         },

--- a/website/src/components/MiniBlog/styles.ts
+++ b/website/src/components/MiniBlog/styles.ts
@@ -136,7 +136,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   tabWrapper: {
     display: "flex",
     overflow: "auto",
-    paddingBottom: '2px',
+    paddingBottom: theme.spacing(0.25),
     width: "70%",
     [theme.breakpoints.down("sm")]: {
       width: "100%",

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -63,7 +63,6 @@ const Blog: React.FC = () => {
   const [page, setPage] = React.useState<number>(1);
   const { width } = useViewport();
   const mobileBreakpoint = VIEW_PORT.MOBILE_BREAKPOINT;
-
   const StyledTab = withStyles((theme: Theme) =>
     createStyles({
       root: {

--- a/website/src/pages/Blog/styles.ts
+++ b/website/src/pages/Blog/styles.ts
@@ -53,8 +53,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '60px',
     marginRight: theme.spacing(1.8),
     [theme.breakpoints.down("xs")]: {
-      width: '48px',
-      height: '48px',
+      width: '32px',
+      height: '32px',
     },
   },
   tabs: {

--- a/website/src/pages/Blog/styles.ts
+++ b/website/src/pages/Blog/styles.ts
@@ -257,7 +257,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   tabWrapper: {
     display: "flex",
     overflow: "auto",
-    paddingBottom: '2px',
+    paddingBottom: theme.spacing(0.25),
     width: "70%",
     [theme.breakpoints.down("sm")]: {
       width: "100%",

--- a/website/src/pages/Blog/styles.ts
+++ b/website/src/pages/Blog/styles.ts
@@ -45,8 +45,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     margin: theme.spacing(3, 0, 2.5),
     [theme.breakpoints.down("xs")]: {
       flexDirection: 'column',
-      margin: theme.spacing(0),
-      gap: theme.spacing(1)
+      margin: theme.spacing(0)
     },
   },
   large: {
@@ -54,8 +53,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '60px',
     marginRight: theme.spacing(1.8),
     [theme.breakpoints.down("xs")]: {
-      width: '32px',
-      height: '32px',
+      width: '48px',
+      height: '48px',
     },
   },
   tabs: {

--- a/website/src/pages/BlogPage/style.ts
+++ b/website/src/pages/BlogPage/style.ts
@@ -104,17 +104,18 @@ const useStyles = makeStyles((theme: Theme) => ({
       flexDirection:'column',
       justifyContent: 'center',
       marginTop: theme.spacing(3),
-      gap: theme.spacing(1)
     },
   },
   share: {
     fontSize: '16px',
     [theme.breakpoints.down('xs')]: {
       fontSize: '14px',
+      marginBottom: theme.spacing(1)
     },
   },
   socialIconsWrapper: {
-    display: 'flex',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(4, 1fr)',
     marginLeft: theme.spacing(1),
     gap: theme.spacing(2),
   },

--- a/website/src/pages/CommercialSupport/styles.ts
+++ b/website/src/pages/CommercialSupport/styles.ts
@@ -91,7 +91,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     [theme.breakpoints.down("sm")]: {
       height: '100%',
-      paddingBottom: '40px',
+      paddingBottom: theme.spacing(5),
       '&:hover':{
         height: '100%'
       }

--- a/website/src/pages/Home/styles.ts
+++ b/website/src/pages/Home/styles.ts
@@ -436,12 +436,14 @@ const useStyles = makeStyles((theme) => ({
         fontWeight: 400,
         color: theme.palette.text.disabled
     },
-    testimonialWriterWrapper: {
-        display: 'flex',
-        alignItems: 'center',
-        gap: '10px',
-        marginTop: theme.spacing(3)
-    },
+    // commented code will be used for upcomming releases
+    // 
+    // testimonialWriterWrapper: {
+    //     display: 'flex',
+    //     alignItems: 'center',
+    //     gap: '10px',
+    //     marginTop: theme.spacing(3)
+    // },
     testimonialMule: {
         margin: theme.spacing(0,4),
         '& img': {


### PR DESCRIPTION
Signed-off-by: isamrish <askmaurya48@gmail.com>

This commit will fix the CSS property gap related issue in safari. When `gap` is being used with `display: flex`, it was causing issue, especially in safari browser.

fixes: https://github.com/openebs/website/issues/133

Some screenshots (fixed ones):

<img width="1220" alt="Screenshot 2021-06-28 at 1 20 01 PM" src="https://user-images.githubusercontent.com/6524419/123613378-ff608200-d820-11eb-8589-943f2b69e166.png">

<img width="487" alt="Screenshot 2021-06-28 at 2 30 09 PM" src="https://user-images.githubusercontent.com/6524419/123613423-08515380-d821-11eb-8af0-6d47e19d2417.png">

<img width="587" alt="Screenshot 2021-06-28 at 2 43 52 PM" src="https://user-images.githubusercontent.com/6524419/123613437-0b4c4400-d821-11eb-854f-0ac0d1235cb8.png">

<img width="1435" alt="Screenshot 2021-06-28 at 11 52 41 AM" src="https://user-images.githubusercontent.com/6524419/123613443-0c7d7100-d821-11eb-8320-85183a2eadcd.png">

