### PR TITLE
(Fix): Pagination and tag selection issue

### DIFF
--- a/website/src/components/CustomTag/styles.ts
+++ b/website/src/components/CustomTag/styles.ts
@@ -3,7 +3,7 @@ import { makeStyles, Theme } from "@material-ui/core/styles";
 const useStyles = makeStyles((theme: Theme) => ({
   tag: {
     fontSize: '1rem',
-    width: "fit-content",
+    width: "max-content",
     padding: theme.spacing(0.1, 4),
     borderRadius: "8px 8px 8px 0px",
     lineHeight: "8px",

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -99,6 +99,7 @@ const Blog: React.FC = () => {
 
   const handleChange = (_event: React.ChangeEvent<{}>, newValue: string) => {
     setValue(newValue);
+    setPage(1);
   };
   // functions to get the blog count for each individual tags
   const totalBlogCount = (jsonMdData || []).filter(
@@ -107,6 +108,7 @@ const Blog: React.FC = () => {
 
   const handleTagSelect = (tags: any) => {
     setValue(tags);
+    setPage(1);
   };
 
   const getTags = (tags: any) => {
@@ -137,6 +139,21 @@ const Blog: React.FC = () => {
       setTagsDistribution(tagsArray.reduce((acum: any,cur: string) => Object.assign(acum,{[cur]: (acum[cur] || 0)+1}),{}));
     }
   }, [jsonMdData]);
+
+  const pagination = () => {
+    return (
+      <Pagination
+      count={
+        filteredData
+          ? Math.ceil(filteredData.length / 6 )
+          : 0
+      }
+      page={page}
+      onChange={(_event, val) => val? setPage(val) : setPage(1)}
+      className={classes.pagination}
+    />
+    );
+  };
 
   const getTagsMarkup = Object.keys(tagsDistribution).map((item: string) => 
           <StyledTab
@@ -247,16 +264,7 @@ const Blog: React.FC = () => {
                     })
                 : ""}
             </Grid>
-            <Pagination
-              count={
-                totalBlogCount > 6
-                  ? Math.ceil(totalBlogCount / 6 + 1)
-                  : Math.ceil(totalBlogCount / 6)
-              }
-              page={page}
-              onChange={(_event, val) => setPage(val)}
-              className={classes.pagination}
-            />
+            {pagination()}
           </div>
         </>
       ) : (
@@ -356,16 +364,7 @@ const Blog: React.FC = () => {
                     })
                 : " "}
             </Grid>
-            <Pagination
-              count={
-                filteredAuthorData.length > 6
-                  ? Math.ceil(filteredAuthorData.length / 6 + 1)
-                  : Math.ceil(filteredAuthorData.length / 6)
-              }
-              page={page}
-              onChange={(_event, val) => setPage(val)}
-              className={classes.pagination}
-            />
+            {pagination()}
           </div>
         </>
       )}


### PR DESCRIPTION
Signed-off-by: AVRahul <a.v.rahul11@gmail.com>

- Fixed the pagination issues, which was causing an extra value after the end blog limit.
- When any tags are been selected, the state for the page was not getting updated, with these changes have any time some tag is selected it will set the page content to 1 from the beginning.
- Fix when the custom tag content increases.