### PR TITLE
Add custom tabs for mobile devices to match the design

### DIFF
--- a/website/public/locale/en/translation.yaml
+++ b/website/public/locale/en/translation.yaml
@@ -240,7 +240,7 @@ blog:
   readMore: Read more
   read: Read
   articles: All articles
-  all: all
+  all: All
   chaosengineering: chaosengineering
   devops: devops
   openebs: openebs

--- a/website/src/components/MiniBlog/index.tsx
+++ b/website/src/components/MiniBlog/index.tsx
@@ -18,7 +18,7 @@ import {
   withStyles,
 } from "@material-ui/core";
 import ReactMarkdown from "react-markdown";
-import { VIEW_PORT } from "../../constants";
+import { BLOG_TAGS, VIEW_PORT } from "../../constants";
 import Carousel from "../Carousel";
 import DisplayAuthorandReadTime from "../DisplayAuthorandReadTime";
 import CustomTag from "../CustomTag";
@@ -187,7 +187,7 @@ const MiniBlog: React.FC = () => {
             >
               <StyledTab
                 label={`${t('blog.all')} (${totalBlogCount})`}
-                value={t("blog.all").toLowerCase()}
+                value={BLOG_TAGS.ALL}
               />
               {getTagsMarkup}
             </Tabs>

--- a/website/src/components/MiniBlog/index.tsx
+++ b/website/src/components/MiniBlog/index.tsx
@@ -111,7 +111,7 @@ const MiniBlog: React.FC = () => {
   ).length;
 
   const filteredData = (jsonMdData || []).filter((tabs: TabProps) => {
-    if (value !== "all") {
+    if (value !== t("blog.all").toLowerCase()) {
       const tagData = tabs.tags.find((el: string) => el === value);
       return tagData === value;
     }
@@ -132,9 +132,7 @@ const MiniBlog: React.FC = () => {
     if (tagsDistribution[item as keyof typeof tagsDistribution] > 1) {
       return (
         <StyledTab
-          label={`${item}(${
-            tagsDistribution[item as keyof typeof tagsDistribution]
-          })`}
+          label={`${item} (${tagsDistribution[item as keyof typeof tagsDistribution]})`}
           value={item}
           key={item}
         />
@@ -188,8 +186,8 @@ const MiniBlog: React.FC = () => {
               orientation={mobileBreakpoint ? "horizontal" : "vertical"}
             >
               <StyledTab
-                label={"All(" + totalBlogCount + ")"}
-                value={t("blog.all")}
+                label={t('blog.all') + " (" + totalBlogCount + ")"}
+                value={t("blog.all").toLowerCase()}
               />
               {getTagsMarkup}
             </Tabs>

--- a/website/src/components/MiniBlog/index.tsx
+++ b/website/src/components/MiniBlog/index.tsx
@@ -186,7 +186,7 @@ const MiniBlog: React.FC = () => {
               orientation={mobileBreakpoint ? "horizontal" : "vertical"}
             >
               <StyledTab
-                label={t('blog.all') + " (" + totalBlogCount + ")"}
+                label={`${t('blog.all')} (${totalBlogCount})`}
                 value={t("blog.all").toLowerCase()}
               />
               {getTagsMarkup}

--- a/website/src/components/MiniBlog/index.tsx
+++ b/website/src/components/MiniBlog/index.tsx
@@ -111,7 +111,7 @@ const MiniBlog: React.FC = () => {
   ).length;
 
   const filteredData = (jsonMdData || []).filter((tabs: TabProps) => {
-    if (value !== t("blog.all").toLowerCase()) {
+    if (value !== BLOG_TAGS.ALL) {
       const tagData = tabs.tags.find((el: string) => el === value);
       return tagData === value;
     }

--- a/website/src/components/MiniBlog/styles.ts
+++ b/website/src/components/MiniBlog/styles.ts
@@ -19,6 +19,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tabRoot: {
     justifyContent: "center",
+    '& .MuiButtonBase-root': {
+      [theme.breakpoints.down('xs')]: {
+        fontSize: '14px',
+      },
+    },
     '& .Mui-selected': {
       color: theme.palette.text.hint,
       background: theme.palette.background.paper,

--- a/website/src/constants/index.tsx
+++ b/website/src/constants/index.tsx
@@ -59,3 +59,7 @@ export enum SCRIPT_STATES {
   ERROR = 'error',
   IDLE = 'idle'
 }
+
+export enum BLOG_TAGS {
+  ALL = 'all'
+}

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -161,16 +161,24 @@ const Blog: React.FC = () => {
     );
   };
 
+  const handleTabClickOnMobile = (newValue: string) => {
+    setValue(newValue);
+    setPage(1);
+  }
+
   const getTagsMarkup = Object.keys(tagsDistribution).map((item: string) => {
     if (tagsDistribution[item as keyof typeof tagsDistribution] > 1) {
       return (
-        <StyledTab
-          label={`${item}(${
-            tagsDistribution[item as keyof typeof tagsDistribution]
-          })`}
-          value={item}
-          key={item}
-        />
+        mediumViewport ? 
+          <StyledTab
+            label={`${item} (${tagsDistribution[item as keyof typeof tagsDistribution]})`}
+            value={item}
+            key = {item}
+          />
+          :
+          <Grid item xs={6} key={item}>
+            <Button className={[classes.tabButton, (value === item) ? classes.activeTabButton : ''].join(' ')} onClick={() => handleTabClickOnMobile(item)}>{item} <span className={(value !== item) ? classes.tagCount : ''}>({tagsDistribution[item as keyof typeof tagsDistribution]})</span></Button>
+          </Grid>
       );
     }
     return null;
@@ -184,26 +192,36 @@ const Blog: React.FC = () => {
             <Container maxWidth="lg">
               <h1 className={classes.mainText}>{t("blog.title")}</h1>
               <Paper className={classes.tabs}>
+                {mediumViewport ?
                 <Tabs
-                  value={value}
-                  onChange={handleChange}
-                  textColor="secondary"
-                  variant="scrollable"
-                  classes={{ 
-                    root: classes.tabRoot, scroller: classes.scroller }}
-                  TabIndicatorProps={{
-                    style: {
-                      display: "none",
-                    },
-                  }}
-                  orientation={mediumViewport ? "horizontal" : "vertical"}
-                >
-                  <StyledTab
-                    label={"All(" + totalBlogCount + ")"}
-                    value={t("blog.all")}
-                  />
+                value={value}
+                onChange={handleChange}
+                textColor="secondary"
+                variant="scrollable"
+                classes={{ 
+                  root: classes.tabRoot, scroller: classes.scroller }}
+                TabIndicatorProps={{
+                  style: {
+                    display: "none",
+                  },
+                }}
+                orientation="horizontal"
+              >
+                <StyledTab
+                  label={t('blog.all') + " (" + totalBlogCount + ")"}
+                  value={t("blog.all").toLowerCase()}
+                />
+                {getTagsMarkup}
+              </Tabs>
+              :
+              <Grid container className={classes.mobileTabsWrapper}>
+                  <Grid item xs={6}>
+                      <Button className={[classes.tabButton, (value === t("blog.all").toLowerCase()) ? classes.activeTabButton : ''].join(' ')} onClick={() => handleTabClickOnMobile(t("blog.all").toLowerCase())}>{t('blog.all')} <span className={(value !== 'all') ? classes.tagCount : ''}>({totalBlogCount})</span></Button>
+                  </Grid>
                   {getTagsMarkup}
-                </Tabs>
+              </Grid>
+            }
+                
               </Paper>
             </Container>
           </div>

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -114,8 +114,8 @@ const Blog: React.FC = () => {
     (tabs: TabProps) => tabs
   ).length;
 
-  const handleTagSelect = (tags: any) => {
-    setValue(tags);
+  const handleTagSelect = (tag: string) => {
+    setValue(tag);
     setPage(1);
   };
 
@@ -161,13 +161,9 @@ const Blog: React.FC = () => {
     );
   };
 
-  const handleTabClickOnMobile = (newValue: string) => {
-    setValue(newValue);
-    setPage(1);
-  }
-
   const getTagsMarkup = Object.keys(tagsDistribution).map((item: string) => {
     if (tagsDistribution[item as keyof typeof tagsDistribution] > 1) {
+      // If medium view port display StyledTab of material-ui else display grid for custom tabs to match Figma design
       return (
         mediumViewport ? 
           <StyledTab
@@ -177,7 +173,7 @@ const Blog: React.FC = () => {
           />
           :
           <Grid item xs={6} key={item}>
-            <Button className={[classes.tabButton, (value === item) ? classes.activeTabButton : ''].join(' ')} onClick={() => handleTabClickOnMobile(item)}>{item} <span className={(value !== item) ? classes.tagCount : ''}>({tagsDistribution[item as keyof typeof tagsDistribution]})</span></Button>
+            <Button className={[classes.tabButton, (value === item) ? classes.activeTabButton : ''].join(' ')} onClick={() => handleTagSelect(item)}>{item} <span className={(value !== item) ? classes.tagCount : ''}>({tagsDistribution[item as keyof typeof tagsDistribution]})</span></Button>
           </Grid>
       );
     }
@@ -216,7 +212,7 @@ const Blog: React.FC = () => {
               :
               <Grid container className={classes.mobileTabsWrapper}>
                   <Grid item xs={6}>
-                      <Button className={[classes.tabButton, (value === t("blog.all").toLowerCase()) ? classes.activeTabButton : ''].join(' ')} onClick={() => handleTabClickOnMobile(t("blog.all").toLowerCase())}>{t('blog.all')} <span className={(value !== 'all') ? classes.tagCount : ''}>({totalBlogCount})</span></Button>
+                      <Button className={[classes.tabButton, (value === t("blog.all").toLowerCase()) ? classes.activeTabButton : ''].join(' ')} onClick={() => handleTagSelect(t("blog.all").toLowerCase())}>{t('blog.all')} <span className={(value !== 'all') ? classes.tagCount : ''}>({totalBlogCount})</span></Button>
                   </Grid>
                   {getTagsMarkup}
               </Grid>

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -173,7 +173,14 @@ const Blog: React.FC = () => {
           />
           :
           <Grid item xs={6} key={item}>
-            <Button className={[classes.tabButton, (value === item) ? classes.activeTabButton : ''].join(' ')} onClick={() => handleTagSelect(item)}>{item} <span className={(value !== item) ? classes.tagCount : ''}>({tagsDistribution[item as keyof typeof tagsDistribution]})</span></Button>
+            <Button 
+              className={[classes.tabButton, (value === item) ? classes.activeTabButton : ''].join(' ')} 
+              onClick={() => handleTagSelect(item)}>
+              {item} 
+              <span className={(value !== item) ? classes.tagCount : ''}>
+                  ({tagsDistribution[item as keyof typeof tagsDistribution]})
+              </span>
+            </Button>
           </Grid>
       );
     }
@@ -204,7 +211,7 @@ const Blog: React.FC = () => {
                 orientation="horizontal"
               >
                 <StyledTab
-                  label={t('blog.all') + " (" + totalBlogCount + ")"}
+                  label={`${t('blog.all')} (${totalBlogCount})`}
                   value={t("blog.all").toLowerCase()}
                 />
                 {getTagsMarkup}
@@ -212,7 +219,12 @@ const Blog: React.FC = () => {
               :
               <Grid container className={classes.mobileTabsWrapper}>
                   <Grid item xs={6}>
-                      <Button className={[classes.tabButton, (value === t("blog.all").toLowerCase()) ? classes.activeTabButton : ''].join(' ')} onClick={() => handleTagSelect(t("blog.all").toLowerCase())}>{t('blog.all')} <span className={(value !== 'all') ? classes.tagCount : ''}>({totalBlogCount})</span></Button>
+                      <Button 
+                        className={[classes.tabButton, (value === t("blog.all").toLowerCase()) ? classes.activeTabButton : ''].join(' ')} 
+                        onClick={() => handleTagSelect(t("blog.all").toLowerCase())}>
+                        {t('blog.all')} 
+                        <span className={(value !== 'all') ? classes.tagCount : ''}>({totalBlogCount})</span>
+                      </Button>
                   </Grid>
                   {getTagsMarkup}
               </Grid>

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@material-ui/core";
 import Footer from "../../components/Footer";
 import ReactMarkdown from "react-markdown";
-import { VIEW_PORT } from "../../constants";
+import { BLOG_TAGS, VIEW_PORT } from "../../constants";
 import Sponsor from "../../components/Sponsor";
 import Pagination from "@material-ui/lab/Pagination";
 import DisplayAuthorandReadTime from "../../components/DisplayAuthorandReadTime";
@@ -212,7 +212,7 @@ const Blog: React.FC = () => {
               >
                 <StyledTab
                   label={`${t('blog.all')} (${totalBlogCount})`}
-                  value={t("blog.all").toLowerCase()}
+                  value={BLOG_TAGS.ALL}
                 />
                 {getTagsMarkup}
               </Tabs>
@@ -220,10 +220,10 @@ const Blog: React.FC = () => {
               <Grid container className={classes.mobileTabsWrapper}>
                   <Grid item xs={6}>
                       <Button 
-                        className={[classes.tabButton, (value === t("blog.all").toLowerCase()) ? classes.activeTabButton : ''].join(' ')} 
-                        onClick={() => handleTagSelect(t("blog.all").toLowerCase())}>
+                        className={[classes.tabButton, (value === BLOG_TAGS.ALL) ? classes.activeTabButton : ''].join(' ')} 
+                        onClick={() => handleTagSelect(BLOG_TAGS.ALL)}>
                         {t('blog.all')} 
-                        <span className={(value !== 'all') ? classes.tagCount : ''}>({totalBlogCount})</span>
+                        <span className={(value !== BLOG_TAGS.ALL) ? classes.tagCount : ''}>({totalBlogCount})</span>
                       </Button>
                   </Grid>
                   {getTagsMarkup}

--- a/website/src/pages/Blog/styles.ts
+++ b/website/src/pages/Blog/styles.ts
@@ -74,6 +74,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tabButton: {
     color: theme.palette.text.secondary,
+    fontSize: '14px'
   },
   activeTabButton: {
     color: theme.palette.text.hint

--- a/website/src/pages/Blog/styles.ts
+++ b/website/src/pages/Blog/styles.ts
@@ -10,7 +10,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundSize: "cover",
     padding: theme.spacing(16, 5, 0),
     [theme.breakpoints.down("xs")]: {
-      padding: theme.spacing(5, 5),
+      padding: theme.spacing(5, 1),
       marginTop: theme.spacing(10),
       backgroundImage: "url(/images/png/faq_background_mobile.png)",
       backgroundRepeat: "no-repeat",
@@ -65,6 +65,22 @@ const useStyles = makeStyles((theme: Theme) => ({
     boxShadow: 'none',
     position: 'relative',
     top: '25px'
+  },
+  mobileTabsWrapper: {
+    background: theme.palette.background.paper,
+    boxShadow: '2px 0px 33px 5px rgba(70, 68, 151, 0.04)',
+    borderRadius: '12px 12px 12px 0px',
+    padding: theme.spacing(2,0)
+  },
+  tabButton: {
+    color: theme.palette.text.secondary,
+  },
+  activeTabButton: {
+    color: theme.palette.text.hint
+  },
+  tagCount: {
+    color: theme.palette.text.disabled,
+    marginLeft: theme.spacing(0.5)
   },
   mainText: {
     display: "flex",


### PR DESCRIPTION
Signed-off-by: Pallavi-PH <pallaviph02@gmail.com>

In this PR we are adding custom tabs for mobile devices to match the design

Tabs on Home page:
<img width="375" alt="Screenshot 2021-07-15 at 12 48 57 PM" src="https://user-images.githubusercontent.com/34312966/125746070-ef509a4e-943f-429e-b67e-ee5d0aa41228.png">


Tabs on Blog page:
<img width="376" alt="Screenshot 2021-07-15 at 12 38 56 PM" src="https://user-images.githubusercontent.com/34312966/125746099-3cd3c506-d51d-4792-9933-88fcde7ef6a3.png">

