### PR TITLE
doc styles for inline code

### DIFF
--- a/docs/src/scss/_colors.scss
+++ b/docs/src/scss/_colors.scss
@@ -40,3 +40,4 @@ $ifm-color-info: rgba(135, 215, 242, 0.3);
 $ifm-color-warning: rgba(255, 208, 77, 0.3);
 $collapse-button-bg-color-dark: #2e333a;
 $ifm-alert-color: $blue-500;
+$ifm-code-background: $blue-100;

--- a/docs/src/scss/custom.scss
+++ b/docs/src/scss/custom.scss
@@ -59,6 +59,7 @@
   --color-light-blue: #{$blue-300};
   --color-lighter-blue: #{$blue-800};
   --color-tealish-blue: #{$blue-400};
+  --ifm-code-background: #{$ifm-code-background};
 }
 
 .markdown {
@@ -119,6 +120,11 @@
     a {
       color: inherit;
     }
+  }
+  code {
+    border-radius: 4px;
+    border: none;
+    color: inherit;
   }
 }
 


### PR DESCRIPTION
Doc style for inline code 

screenshot : 
![image](https://user-images.githubusercontent.com/75615087/127116265-0de2de84-82e6-492a-a205-61755fa2f430.png)
