### PR TITLE
Fix links in troubleshooting section

### DIFF
--- a/docs/versioned_docs/version-2.11.0/troubleshooting/cstor.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/cstor.md
@@ -513,4 +513,4 @@ cstor-cspc-zdvk   ip-192-168-29-217   98k        9630M  9630098k  false     1   
 
 ## See Also:
 
-[FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[FAQs](/docs/additional-info/faqs) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/install.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/install.md
@@ -127,4 +127,4 @@ A multipath.conf file without either find_multipaths or a manual blacklist claim
 
 ## See Also:
 
-[FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[FAQs](/docs/additional-info/faqs) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/jiva.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/jiva.md
@@ -68,4 +68,4 @@ Perform following steps to restore the missing metadata file of internal snapsho
 
 ## See Also:
 
-[FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[FAQs](/docs/additional-info/faqs) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/localpv.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/localpv.md
@@ -140,4 +140,4 @@ spec:
 
 ## See Also:
 
-[FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[FAQs](/docs/additional-info/faqs) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/ndm.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/ndm.md
@@ -101,4 +101,4 @@ wipefs -fa /dev/sdb
 
 ## See Also:
 
-[FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[FAQs](/docs/additional-info/faqs) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/ndm.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/ndm.md
@@ -102,7 +102,3 @@ wipefs -fa /dev/sdb
 ## See Also:
 
 [FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
-
-```
-
-```

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/troubleshooting.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/troubleshooting.md
@@ -1,17 +1,18 @@
 ---
 id: troubleshooting
 title: Troubleshooting OpenEBS - Overview
+slug: /troubleshooting/
 ---
 
 ### General guidelines for troubleshooting
 
 - Search for similar issues mentioned in this page as well as the following troubleshooting sections.
-  - [Troubleshooting Install](/docs/troubleshooting/t-install).
-  - [Troubleshooting Uninstall](/docs/troubleshooting/t-uninstall).
-  - [Troubleshooting NDM](/docs/troubleshooting/t-ndm).
-  - [Troubleshooting Jiva](/docs/troubleshooting/t-jiva).
-  - [Troubleshooting cStor](/docs/troubleshooting/t-cstor).
-  - [Troubleshooting LocalPV](/docs/troubleshooting/t-localpv).
+  - [Troubleshooting Install](/docs/troubleshooting/install).
+  - [Troubleshooting Uninstall](/docs/troubleshooting/uninstall).
+  - [Troubleshooting NDM](/docs/troubleshooting/ndm).
+  - [Troubleshooting Jiva](/docs/troubleshooting/jiva).
+  - [Troubleshooting cStor](/docs/troubleshooting/cstor).
+  - [Troubleshooting LocalPV](/docs/troubleshooting/localpv).
 - Contact [OpenEBS Community](/docs/introduction/community) for support.
 - Search for similar issues on [OpenEBS GitHub repository](https://github.com/openebs/openebs/issues).
 - Search for any reported issues on [StackOverflow under OpenEBS tag](https://stackoverflow.com/questions/tagged/openebs).
@@ -186,4 +187,4 @@ Set the reboot timer schedule at different time i.e staggered at various interva
 
 ## See Also:
 
-[Troubleshooting Install](/docs/troubleshooting/t-install) [Troubleshooting Uninstall](/docs/troubleshooting/t-uninstall) [Troubleshooting NDM](/docs/troubleshooting/t-ndm) [Troubleshooting Jiva](/docs/troubleshooting/t-jiva) [Troubleshooting cStor](/docs/troubleshooting/t-cstor) [Troubleshooting Local PV](/docs/troubleshooting/t-localpv) [Troubleshooting Mayastor](/docs/troubleshooting/t-mayastor) [FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[Troubleshooting Install](/docs/troubleshooting/install) [Troubleshooting Uninstall](/docs/troubleshooting/uninstall) [Troubleshooting NDM](/docs/troubleshooting/ndm) [Troubleshooting Jiva](/docs/troubleshooting/jiva) [Troubleshooting cStor](/docs/troubleshooting/cstor) [Troubleshooting Local PV](/docs/troubleshooting/localpv) [Troubleshooting Mayastor](/docs/troubleshooting/mayastor) [FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/troubleshooting.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 id: troubleshooting
 title: Troubleshooting OpenEBS - Overview
-slug: /troubleshooting/
+slug: /troubleshooting
 ---
 
 ### General guidelines for troubleshooting
@@ -187,4 +187,4 @@ Set the reboot timer schedule at different time i.e staggered at various interva
 
 ## See Also:
 
-[Troubleshooting Install](/docs/troubleshooting/install) [Troubleshooting Uninstall](/docs/troubleshooting/uninstall) [Troubleshooting NDM](/docs/troubleshooting/ndm) [Troubleshooting Jiva](/docs/troubleshooting/jiva) [Troubleshooting cStor](/docs/troubleshooting/cstor) [Troubleshooting Local PV](/docs/troubleshooting/localpv) [Troubleshooting Mayastor](/docs/troubleshooting/mayastor) [FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[Troubleshooting Install](/docs/troubleshooting/install) [Troubleshooting Uninstall](/docs/troubleshooting/uninstall) [Troubleshooting NDM](/docs/troubleshooting/ndm) [Troubleshooting Jiva](/docs/troubleshooting/jiva) [Troubleshooting cStor](/docs/troubleshooting/cstor) [Troubleshooting Local PV](/docs/troubleshooting/localpv) [Troubleshooting Mayastor](/docs/troubleshooting/mayastor) [FAQs](/docs/additional-info/faqs) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/uninstall.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/uninstall.md
@@ -44,4 +44,4 @@ This will automatically remove the pending CVR and delete the cStor volume compl
 
 ## See Also:
 
-[FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[FAQs](/docs/additional-info/faqs) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/volume-provisioning.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/volume-provisioning.md
@@ -535,4 +535,4 @@ To avoid this issue, open the port `5656/tcp` on the nodes that run the OpenEBS 
 
 ## See Also:
 
-[FAQs](/docs/next/faq.html) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)
+[FAQs](/docs/additional-info/faqs) [Seek support or help](/docs/introduction/community) [Latest release notes](/docs/introduction/releases)


### PR DESCRIPTION
Signed-off-by: isamrish <askmaurya48@gmail.com>

This PR will fix
- link in troubleshooting page
- `/troubleshooting/troubleshooting/` => `/troubleshooting/`