### PR TITLE
(docs) : Removed unwanted rule from styles

### DIFF
--- a/docs/src/theme/DocPage/styles.module.scss
+++ b/docs/src/theme/DocPage/styles.module.scss
@@ -74,9 +74,6 @@
     width: auto;
   }
 
-  .colMainContent {
-    width: calc(100vw - (var(--doc-sidebar-width)));
-  }
   .docMainContainerEnhanced {
     max-width: none;
   }


### PR DESCRIPTION
This PR will remove the unwanted rule present in the styles, which caused the horizontal overflow

before:
![image](https://user-images.githubusercontent.com/75615087/128464677-12868a89-cb1d-42b9-b911-85d9485ad502.png)

after:
![image](https://user-images.githubusercontent.com/75615087/128464725-ee424e51-50da-4b10-b323-8d43062e0d2b.png)
