### PR TITLE
Adjust font-size of anchor tags to match rest of the content in docs

### DIFF
--- a/docs/src/scss/_typography.scss
+++ b/docs/src/scss/_typography.scss
@@ -39,7 +39,7 @@ li {
 }
 
 a {
-  font-size: 14px;
+  font-size: 16px;
 }
 
 thead {


### PR DESCRIPTION
Signed-off-by: Pallavi-PH <pallaviph02@gmail.com>

In this PR , we are adjusting font-size of anchor tags to match the rest of the content in docs