### PR TITLE
(SEO) Add description and keywords for troubleshooting related pages

### DIFF
--- a/docs/versioned_docs/version-2.11.0/troubleshooting/cstor.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/cstor.md
@@ -2,6 +2,7 @@
 id: cstor
 title: Troubleshooting OpenEBS - cStor
 keywords:
+  - OpenEBS
   - cStor
   - cStor troubleshooting
 description: This page contains a list of cStor related troubleshooting information.

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/cstor.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/cstor.md
@@ -1,6 +1,10 @@
 ---
 id: cstor
 title: Troubleshooting OpenEBS - cStor
+keywords:
+  - cStor
+  - cStor troubleshooting
+description: This page contains a list of cStor related troubleshooting information.
 ---
 
 ## General guidelines for troubleshooting
@@ -110,7 +114,7 @@ $ kubectl get po -n openebs -l app=cstor-pool
 
 Sample Output:
 
- ```shell hideCopy
+```shell hideCopy
 NAME                               READY   STATUS    RESTARTS   AGE
 cstor-cspc-chjg-85f65ff79d-pq9d2   0/3     Pending   0          16m
 cstor-cspc-h99x-57888d4b5-kh42k    0/3     Pending   0          15m
@@ -363,7 +367,7 @@ $ kubectl get cvr -n openebs
 
 Sample Output:
 
- ```shell hideCopy
+```shell hideCopy
 NAME                                                       USED   ALLOCATED   STATUS    AGE
 pvc-81746e7a-a29d-423b-a048-76edab0b0826-cstor-cspc-xnxx   6K     6K          Healthy   52m
 pvc-81746e7a-a29d-423b-a048-76edab0b0826-cstor-cspc-zdvk   6K     6K          Healthy   52m
@@ -377,7 +381,7 @@ $ kubectl describe cvc <pv_name> -n openebs
 
 Sample Output:
 
- ```shell hideCopy
+```shell hideCopy
 Events:
 Type     Reason                 Age    From                         Message
 ----     ------                 ----   ----                         -------
@@ -404,7 +408,7 @@ $ kubectl get cspc -n openebs
 
 Sample Output:
 
- ```shell hideCopy
+```shell hideCopy
 NAME         HEALTHYINSTANCES   PROVISIONEDINSTANCES   DESIREDINSTANCES   AGE
 cstor-cspc   2                  3                      2                  56m
 ```
@@ -443,7 +447,7 @@ $ kubectl get cspi -n openebs
 
 Sample Output:
 
- ```shell hideCopy
+```shell hideCopy
 NAME             HOSTNAME           ALLOCATED  FREE   CAPACITY  READONLY  PROVISIONEDREPLICAS  HEALTHYREPLICAS  TYPE    STATUS  AGE
 cstor-cspc-bf9h  ip-192-168-49-174  230k       9630M  9630230k  false     0                    0                stripe  ONLINE  66s
 ```
@@ -487,7 +491,7 @@ $ kubectl get cvr -n openebs
 
 Sample Output:
 
- ```shell hideCopy
+```shell hideCopy
 NAME                                                       USED   ALLOCATED   STATUS    AGE
 pvc-81746e7a-a29d-423b-a048-76edab0b0826-cstor-cspc-bf9h   6K     6K          Healthy   11m
 pvc-81746e7a-a29d-423b-a048-76edab0b0826-cstor-cspc-xnxx   6K     6K          Healthy   96m
@@ -503,7 +507,7 @@ $ kubectl get cspi -n openebs
 
 Sample Output:
 
- ```shell hideCopy
+```shell hideCopy
 NAME              HOSTNAME            ALLOCATED  FREE   CAPACITY  READONLY  PROVISIONEDREPLICAS  HEALTHYREPLICAS  TYPE    STATUS  AGE
 cstor-cspc-bf9h  ip-192-168-49-174    230k       9630M  9630230k  false     1                    1                stripe  ONLINE  66s
 cstor-cspc-xnxx   ip-192-168-79-76    101k       9630M  9630101k  false     1                    1                stripe  ONLINE  4m25s

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/install.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/install.md
@@ -2,6 +2,7 @@
 id: install
 title: Troubleshooting OpenEBS Install
 keywords:
+  - OpenEBS
   - OpenEBS installation
   - OpenEBS installation troubleshooting
 description: This page contains list of OpenEBS installation related troubleshooting information.

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/install.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/install.md
@@ -1,6 +1,10 @@
 ---
 id: install
 title: Troubleshooting OpenEBS Install
+keywords:
+  - OpenEBS installation
+  - OpenEBS installation troubleshooting
+description: This page contains list of OpenEBS installation related troubleshooting information.
 ---
 
 ## General guidelines for troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/jiva.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/jiva.md
@@ -2,6 +2,7 @@
 id: jiva
 title: Troubleshooting OpenEBS - Jiva
 keywords:
+  - OpenEBS
   - Jiva
   - Jiva troubleshooting
 description: This page contains a list of Jiva related troubleshooting information.

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/jiva.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/jiva.md
@@ -1,6 +1,10 @@
 ---
 id: jiva
 title: Troubleshooting OpenEBS - Jiva
+keywords:
+  - Jiva
+  - Jiva troubleshooting
+description: This page contains a list of Jiva related troubleshooting information.
 ---
 
 ## General guidelines for troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/localpv.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/localpv.md
@@ -1,6 +1,12 @@
 ---
 id: localpv
 title: Troubleshooting OpenEBS - Dynamic LocalPV
+keywords:
+  - LocalPV
+  - Dynamic LocalPV
+  - LocalPV troubleshooting
+  - Dynamic LocalPV troubleshooting
+description: This page contains a list of Dynamic LocalPV / LocalPV related troubleshooting information.
 ---
 
 ### General guidelines for troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/localpv.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/localpv.md
@@ -2,6 +2,7 @@
 id: localpv
 title: Troubleshooting OpenEBS - Dynamic LocalPV
 keywords:
+  - OpenEBS
   - LocalPV
   - Dynamic LocalPV
   - LocalPV troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/mayastor.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/mayastor.md
@@ -2,6 +2,7 @@
 id: mayastor
 title: Troubleshooting Mayastor
 keywords:
+  - OpenEBS
   - Mayastor
   - Mayastor troubleshooting
 description: This page contains information regarding Mayastor related troubleshooting.

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/mayastor.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/mayastor.md
@@ -1,6 +1,10 @@
 ---
 id: mayastor
 title: Troubleshooting Mayastor
+keywords:
+  - Mayastor
+  - Mayastor troubleshooting
+description: This page contains information regarding Mayastor related troubleshooting.
 ---
 
 ## Troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/ndm.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/ndm.md
@@ -1,6 +1,13 @@
 ---
 id: ndm
 title: Troubleshooting OpenEBS - NDM
+keywords:
+  - NDM
+  - NDM troubleshooting
+  - OpenEBS NDM
+  - OpenEBS NDM troubleshooting
+  - Node Disk Manager
+description: This page contains a list of Node Disk Manager (NDM) related troubleshooting information.
 ---
 
 ## General guidelines for troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/ndm.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/ndm.md
@@ -2,6 +2,7 @@
 id: ndm
 title: Troubleshooting OpenEBS - NDM
 keywords:
+  - OpenEBS
   - NDM
   - NDM troubleshooting
   - OpenEBS NDM

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/troubleshooting.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/troubleshooting.md
@@ -2,6 +2,10 @@
 id: troubleshooting
 title: Troubleshooting OpenEBS - Overview
 slug: /troubleshooting
+keywords:
+  - OpenEBS
+  - OpenEBS troubleshooting
+description: This page contains a list of OpenEBS related troubleshooting which contains information like troubleshooting installation, troubleshooting uninstallation, troubleshooting NDM, troubleshooting Jiva, troubleshooting cStor, troubleshooting Mayastor and troubleshooting LocalPV.
 ---
 
 ### General guidelines for troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/uninstall.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/uninstall.md
@@ -2,6 +2,7 @@
 id: uninstall
 title: Troubleshooting OpenEBS - Uninstall
 keywords:
+  - OpenEBS
   - OpenEBS uninstallation
   - OpenEBS uninstallation troubleshooting
 description: This page contains a list of OpenEBS uninstallation related troubleshooting information.

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/uninstall.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/uninstall.md
@@ -1,6 +1,10 @@
 ---
 id: uninstall
 title: Troubleshooting OpenEBS - Uninstall
+keywords:
+  - OpenEBS uninstallation
+  - OpenEBS uninstallation troubleshooting
+description: This page contains a list of OpenEBS uninstallation related troubleshooting information.
 ---
 
 ## General guidelines for troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/volume-provisioning.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/volume-provisioning.md
@@ -1,6 +1,10 @@
 ---
 id: volume-provisioning
 title: Troubleshooting OpenEBS - Provisioning
+keywords:
+  - Volume Provisioning
+  - Volume Provisioning troubleshooting
+description: This page contains a list of volume provisioning related troubleshooting information.
 ---
 
 ## General guidelines for troubleshooting

--- a/docs/versioned_docs/version-2.11.0/troubleshooting/volume-provisioning.md
+++ b/docs/versioned_docs/version-2.11.0/troubleshooting/volume-provisioning.md
@@ -2,6 +2,7 @@
 id: volume-provisioning
 title: Troubleshooting OpenEBS - Provisioning
 keywords:
+  - OpenEBS
   - Volume Provisioning
   - Volume Provisioning troubleshooting
 description: This page contains a list of volume provisioning related troubleshooting information.


### PR DESCRIPTION
Signed-off-by: isamrish <askmaurya48@gmail.com>

This PR will add two new fields in every page related to troubleshooting.
The fields are
- description
- keywords

This will help in improving the SEO for the troubleshooting pages