### PR TITLE
(docs) : Version dropdown positioning

### DIFF
--- a/docs/src/components/VersionDropdown/index.js
+++ b/docs/src/components/VersionDropdown/index.js
@@ -62,7 +62,7 @@ export const VersionDropdown = () => {
   return (
     <div className={styles.dropDownWrapper}>
       <div
-        className={`dropdown dropdown--hoverable doc-button doc-button-outlined doc-button-secondary doc-button-secondary-light ${styles.dropdown}`}
+        className={`dropdown dropdown--hoverable doc-button doc-button-outlined doc-button-secondary doc-button-secondary-light dropdown--right ${styles.dropdown}`}
       >
         <span className="navbar__link">{currentOption.name}</span>
         <ul className="dropdown__menu">


### PR DESCRIPTION
1. On mobile devices the dropdown was going towards the right side which caused a scrollbar issue
2. Adding dropdown--right ([infima](https://infima.dev/docs/components/dropdown)) to the dropdown class fixed the issue

before:
![image](https://user-images.githubusercontent.com/75615087/128550059-0d5d4818-5bd2-4862-8ee6-73293b8f41c3.png)

after:
![image](https://user-images.githubusercontent.com/75615087/128550023-71b61597-3c74-440d-9cbf-80e2f937b3d6.png)
