### PR TITLE
Adding separate route and page for Blog tags

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -14,6 +14,7 @@ const CommercialSupport = React.lazy(() => import('./pages/CommercialSupport'));
 const Community = React.lazy(() => import('./pages/Community'));
 const Blog = React.lazy(() => import('./pages/Blog'));
 const AuthorBlogs = React.lazy(() => import('./pages/Blog/Author'));
+const TagBlogs = React.lazy(() => import('./pages/Blog/Tag'));
 const BlogPage = React.lazy(() => import('./pages/BlogPage'));
 const ErrorPage = React.lazy(() => import('./pages/ErrorPage'));
 
@@ -26,7 +27,6 @@ const Routes: React.FC = () => {
           {/* ---All routes should be wrapped within scaffold--- */}
           <Switch>
             {/* ---Routes to come beneath--- */}
-
             <Route exact path='/' component={Home} />
             <Route exact path='/privacy-policy' component={PrivacyPolicy} />
             <Route exact path='/faq' component={Faq} />
@@ -34,6 +34,7 @@ const Routes: React.FC = () => {
             <Route exact path='/commercial-support' component={CommercialSupport} />
             <Route exact path='/blog' component={Blog} />
             <Route exact path='/blog/author/:authorName' component={AuthorBlogs} />
+            <Route exact path='/blog/tag/:tagName' component={TagBlogs} />
             <Route exact path='/blog/:blogName' component={BlogPage} />
             <Route path='*' component={ErrorPage} />
           </Switch>

--- a/website/src/components/BlogCard/index.tsx
+++ b/website/src/components/BlogCard/index.tsx
@@ -10,7 +10,6 @@ import { getContentPreview } from "../../utils/getContent";
 import CustomTag from "../CustomTag";
 
 interface BlogCardProps {
-    isAuthorPage: boolean;
     blog: { 
             title: string;
             author: string;
@@ -25,21 +24,21 @@ interface BlogCardProps {
     handleTagSelect: (tag: string) => void;
 }
 
-const BlogCard: React.FC<BlogCardProps> = ({ blog, isAuthorPage, handleTagSelect }) => {
+const BlogCard: React.FC<BlogCardProps> = ({ blog, handleTagSelect }) => {
     const { t } = useTranslation();
     const classes = useStyles();
     const history = useHistory();
 
     const handleRedirectPath = (slug: string) => {
         history.push(`/blog/${slug}`);
-      };
+    };
 
     const getTags = (tags: string[]) => {
         return tags.map((tag: string) => (
         <button
             key={tag}
             onClick={() => handleTagSelect(tag)}
-            className={[classes.tagButton, !isAuthorPage ? classes.cursorPointer : ''].join(' ')}
+            className={classes.tagButton}
         >
             <CustomTag blogLabel={tag} key={tag} />
         </button>

--- a/website/src/components/BlogCard/style.ts
+++ b/website/src/components/BlogCard/style.ts
@@ -5,8 +5,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         border: "none",
         background: "none",
         marginRight: theme.spacing(1),
-    },
-    cursorPointer: {
         cursor: "pointer",
     },
     card: {

--- a/website/src/components/BlogsSlider/index.tsx
+++ b/website/src/components/BlogsSlider/index.tsx
@@ -66,7 +66,7 @@ const BlogsSlider: React.FC<BlogsSliderProps> = ({ recommendedBlogs }) => {
   };
 
   const handleTagSelect = (tag: string) => {
-    history.push(`/blog/tag/${tag}`);
+    history.push(`/blog/tag/${tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-')}`);
   };
 
   return (

--- a/website/src/components/BlogsSlider/index.tsx
+++ b/website/src/components/BlogsSlider/index.tsx
@@ -53,12 +53,20 @@ const BlogsSlider: React.FC<BlogsSliderProps> = ({ recommendedBlogs }) => {
   const getTags = (tags: Array<string>) => {
     const tagItems = tags.map((tag) => {
       return (
-        <div className={classes.tag} key={tag}>
-          <CustomTag blogLabel={tag} />
-        </div>
+        <button
+          key={tag}
+          onClick={() => handleTagSelect(tag)}
+          className={classes.tag}
+        >
+            <CustomTag blogLabel={tag} />
+        </button>
       );
     });
     return tagItems;
+  };
+
+  const handleTagSelect = (tag: string) => {
+    history.push(`/blog/tag/${tag}`);
   };
 
   return (

--- a/website/src/components/BlogsSlider/index.tsx
+++ b/website/src/components/BlogsSlider/index.tsx
@@ -15,6 +15,7 @@ import ReactMarkdown from "react-markdown";
 import { getContentPreview } from "../../utils/getContent";
 import BlogImage from '../BlogImage';
 import { useHistory } from "react-router-dom";
+import { toLowerCaseHyphenSeparatedString } from "../../utils/stringConversions";
 
 interface BlogsSliderProps {
   recommendedBlogs: any;
@@ -66,7 +67,7 @@ const BlogsSlider: React.FC<BlogsSliderProps> = ({ recommendedBlogs }) => {
   };
 
   const handleTagSelect = (tag: string) => {
-    history.push(`/blog/tag/${tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-')}`);
+    history.push(`/blog/tag/${toLowerCaseHyphenSeparatedString(tag)}`);
   };
 
   return (

--- a/website/src/components/BlogsSlider/style.ts
+++ b/website/src/components/BlogsSlider/style.ts
@@ -33,9 +33,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingBottom: theme.spacing(0.75),
   },
   tag: {
-    marginRight: theme.spacing(1)
+    marginRight: theme.spacing(1),
+    border: 'none',
+    background: 'transparent',
+    padding: theme.spacing(0),
+    cursor: 'pointer'
   },
-
   title: {
     fontSize: 22,
     fontWeight: 700,

--- a/website/src/components/CustomTag/styles.ts
+++ b/website/src/components/CustomTag/styles.ts
@@ -10,6 +10,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.down("xs")]: {
       fontSize: '0.75rem'
     },
+    '& p':{
+      lineHeight: "inherit !important",
+    }
   },
 }));
 

--- a/website/src/components/Header/index.tsx
+++ b/website/src/components/Header/index.tsx
@@ -78,7 +78,7 @@ const Header: React.FC = () => {
                         onClick: handleDrawerOpen,
                     }}
                     >
-                    <img loading="lazy" src="../images/svg/hamburger.svg" alt={t('header.menuAlt')}></img>
+                    <img loading="lazy" src="/images/svg/hamburger.svg" alt={t('header.menuAlt')}></img>
                     </IconButton>
                 </div>
                 <Drawer elevation={0}
@@ -91,7 +91,7 @@ const Header: React.FC = () => {
                     <div className={classes.drawerPaper}>
                         <div className={classes.closeIcon}>
                             <IconButton aria-label="close drawer" onClick={() => handleDrawerClose()}>
-                                <img loading="lazy" src="../images/svg/x-circle.svg" alt={t('header.closeMenuAlt')}/>
+                                <img loading="lazy" src="/images/svg/x-circle.svg" alt={t('header.closeMenuAlt')}/>
                             </IconButton>
                         </div>
                         <div className={classes.mobileNavWrapper}>

--- a/website/src/hooks/extractBlogPath.ts
+++ b/website/src/hooks/extractBlogPath.ts
@@ -12,4 +12,10 @@ const useAuthorName = () => {
   return location.pathname.split("/blog/author/").pop();
 };
 
-export { useBlogName, useAuthorName };
+// custom hook for getting blog tag from the URL
+const useTag = () => {
+  const location = useLocation();
+  return location.pathname.split("/blog/tag/").pop();
+};
+
+export { useBlogName, useAuthorName, useTag };

--- a/website/src/pages/Blog/Author/index.tsx
+++ b/website/src/pages/Blog/Author/index.tsx
@@ -149,7 +149,7 @@ const Blog: React.FC = () => {
                           key={elm.id}
                           className={classes.cardSize}
                         >
-                          <BlogCard blog={elm} handleTagSelect={(tag: string) => history.push(`/blog/tag/${tag}`)}></BlogCard>
+                          <BlogCard blog={elm} handleTagSelect={(tag: string) => history.push(`/blog/tag/${tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-')}`)}></BlogCard>
                         </Grid>
                       );
                     })

--- a/website/src/pages/Blog/Author/index.tsx
+++ b/website/src/pages/Blog/Author/index.tsx
@@ -21,6 +21,7 @@ import { Pagination } from "@material-ui/lab";
 import BlogCard from "../../../components/BlogCard";
 import ErrorPage from "../../ErrorPage";
 import { useHistory } from "react-router-dom";
+import { toLowerCaseHyphenSeparatedString } from "../../../utils/stringConversions";
 
 interface BlogItem { 
   title: string;
@@ -68,7 +69,7 @@ const Blog: React.FC = () => {
     const fetchBlogs = async () => {
       const { default: blogs } = await import(`../../../posts.json`);
       const filteredBlogsByAuthorName = blogs.filter(
-        (blog: BlogItem) => blog.author.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-') === authorName
+        (blog: BlogItem) => toLowerCaseHyphenSeparatedString(blog.author) === authorName
       );
       setAuthorBlogData(filteredBlogsByAuthorName);
     };
@@ -149,7 +150,7 @@ const Blog: React.FC = () => {
                           key={elm.id}
                           className={classes.cardSize}
                         >
-                          <BlogCard blog={elm} handleTagSelect={(tag: string) => history.push(`/blog/tag/${tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-')}`)}></BlogCard>
+                          <BlogCard blog={elm} handleTagSelect={(tag: string) => history.push(`/blog/tag/${toLowerCaseHyphenSeparatedString(tag)}`)}></BlogCard>
                         </Grid>
                       );
                     })

--- a/website/src/pages/Blog/Author/index.tsx
+++ b/website/src/pages/Blog/Author/index.tsx
@@ -20,6 +20,7 @@ import { useAuthorName } from "../../../hooks/extractBlogPath";
 import { Pagination } from "@material-ui/lab";
 import BlogCard from "../../../components/BlogCard";
 import ErrorPage from "../../ErrorPage";
+import { useHistory } from "react-router-dom";
 
 interface blog { 
   title: string;
@@ -61,6 +62,7 @@ const Blog: React.FC = () => {
   const [page, setPage] = React.useState<number>(1);
   const { width } = useViewport();
   const mobileBreakpoint = VIEW_PORT.MOBILE_BREAKPOINT;
+  const history = useHistory();
 
   const fetchBlogs = async () => {
     const { default: blogs } = await import(`../../../posts.json`);
@@ -149,7 +151,7 @@ const Blog: React.FC = () => {
                           key={elm.id}
                           className={classes.cardSize}
                         >
-                          <BlogCard isAuthorPage={true} blog={elm} handleTagSelect={() => {}}></BlogCard>
+                          <BlogCard blog={elm} handleTagSelect={(tag: string) => history.push(`/blog/tag/${tag}`)}></BlogCard>
                         </Grid>
                       );
                     })

--- a/website/src/pages/Blog/Tag/index.tsx
+++ b/website/src/pages/Blog/Tag/index.tsx
@@ -44,7 +44,7 @@ const Blog: React.FC = () => {
       id: 0,
       slug: "" }
   ]);
-  const selectedTag = useTag() || '';
+  const selectedTag = useTag();
   const itemsPerPage = 6;
   const [page, setPage] = React.useState<number>(1);
   const history = useHistory();
@@ -52,7 +52,7 @@ const Blog: React.FC = () => {
   const fetchBlogs = async () => {
     const { default: blogs } = await import(`../../../posts.json`);
     const filteredData = blogs.filter(
-      (blog: blog) => blog.tags.find((tag: string) => tag.toLowerCase() === selectedTag.toLowerCase())
+      (blog: blog) => blog.tags.find((tag: string) => tag.toLowerCase() === selectedTag?.toLowerCase())
     );
     setFilteredData(filteredData);
   };

--- a/website/src/pages/Blog/Tag/index.tsx
+++ b/website/src/pages/Blog/Tag/index.tsx
@@ -17,7 +17,7 @@ import BlogCard from "../../../components/BlogCard";
 import { useTag } from "../../../hooks/extractBlogPath";
 import { useHistory } from "react-router-dom";
 
-interface blog { 
+interface blogObject { 
   title: string;
   author: string;
   excerpt: string;
@@ -29,11 +29,11 @@ interface blog {
   slug: string; 
 }
 
-const Blog: React.FC = () => {
+const Tag: React.FC = () => {
   const { t } = useTranslation();
   const classes = useStyles();
   const { currentOrigin } = useCurrentHost();
-  const [filteredData, setFilteredData] = useState<blog[]>([
+  const [filteredData, setFilteredData] = useState<blogObject[]>([
     { title: "",
       author: "",
       excerpt: "",
@@ -52,9 +52,15 @@ const Blog: React.FC = () => {
   const fetchBlogs = async () => {
     const { default: blogs } = await import(`../../../posts.json`);
     const filteredData = blogs.filter(
-      (blog: blog) => blog.tags.find((tag: string) => tag.toLowerCase() === selectedTag?.toLowerCase())
+      (blog: blogObject) => blog.tags.find((tag: string) => tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-') === selectedTag?.toLowerCase())
     );
     setFilteredData(filteredData);
+  };
+
+  const handleTagSelect = (tag: string) => {
+    if(selectedTag !== tag){
+      history.push(`/blog/tag/${tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-')}`)
+    }
   };
 
   useEffect(() => {
@@ -68,7 +74,6 @@ const Blog: React.FC = () => {
 
   const changePage = (val:number = 1) => {
     setPage(val);
-    setPage(1);
     scrollToTop();
   }
 
@@ -108,7 +113,7 @@ const Blog: React.FC = () => {
                           className={classes.cardSize}
                         >
                           {/* Passing parameters blog(passing complete blog object), and handleTagSelect(this fuction handles the action when tag button is clicked)  */}
-                          <BlogCard blog={elm} handleTagSelect={(tag: string) => history.push(`/blog/tag/${tag}`)}></BlogCard>
+                          <BlogCard blog={elm} handleTagSelect={(tag:string) => handleTagSelect(tag)}></BlogCard>
                         </Grid>
                       );
                     })
@@ -129,4 +134,4 @@ const Blog: React.FC = () => {
     </>
   );
 };
-export default Blog;
+export default Tag;

--- a/website/src/pages/Blog/Tag/index.tsx
+++ b/website/src/pages/Blog/Tag/index.tsx
@@ -32,7 +32,7 @@ interface blogObject {
 const Tag: React.FC = () => {
   const { t } = useTranslation();
   const classes = useStyles();
-  const { currentOrigin } = useCurrentHost();
+  const { currentOrigin, currentLocation } = useCurrentHost();
   const [filteredData, setFilteredData] = useState<blogObject[]>([
     { title: "",
       author: "",
@@ -49,13 +49,7 @@ const Tag: React.FC = () => {
   const [page, setPage] = React.useState<number>(1);
   const history = useHistory();
 
-  const fetchBlogs = async () => {
-    const { default: blogs } = await import(`../../../posts.json`);
-    const filteredData = blogs.filter(
-      (blog: blogObject) => blog.tags.find((tag: string) => tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-') === selectedTag?.toLowerCase())
-    );
-    setFilteredData(filteredData);
-  };
+  
 
   const handleTagSelect = (tag: string) => {
     if(selectedTag !== tag){
@@ -64,8 +58,14 @@ const Tag: React.FC = () => {
   };
 
   useEffect(() => {
+    const fetchBlogs = async () => {
+      const { default: blogs } = await import(`../../../posts.json`);
+      const filteredData = blogs.filter(
+        (blog: blogObject) => blog.tags.find((tag: string) => tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-') === selectedTag?.toLowerCase())
+      );
+      setFilteredData(filteredData);
+    };
     fetchBlogs();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   },[selectedTag]);
 
   const scrollToTop = () => {
@@ -90,7 +90,13 @@ const Tag: React.FC = () => {
 
   return (
     <>
-     <Metadata title={SeoJson.pages.blog.title} description={SeoJson.pages.blog.description} url={`${currentOrigin}${SeoJson.pages.blog.url}`} image={`${currentOrigin}${SeoJson.pages.blog.image}`} isPost={false} type={METADATA_TYPES.SERIES}  />
+      <Metadata 
+        title={SeoJson.pages.blog.title} 
+        description={SeoJson.pages.blog.description} 
+        url={currentLocation} 
+        image={`${currentOrigin}/images/seo/openebs.png`} 
+        isPost={false}
+        type={METADATA_TYPES.SERIES} />
         <>
           <div className={classes.root}>
             <Container maxWidth="lg">

--- a/website/src/pages/Blog/Tag/index.tsx
+++ b/website/src/pages/Blog/Tag/index.tsx
@@ -16,7 +16,7 @@ import { Metadata } from "../../../components/Metadata";
 import BlogCard from "../../../components/BlogCard";
 import { useTag } from "../../../hooks/extractBlogPath";
 import { useHistory } from "react-router-dom";
-import { capitalizeTextTransform, toLowerCaseHyphenSeparatedString, replaceHyphenWithSpace } from "../../../utils/stringConversions";
+import { toLowerCaseHyphenSeparatedString } from "../../../utils/stringConversions";
 
 interface blogObject { 
   title: string;
@@ -50,12 +50,14 @@ const Tag: React.FC = () => {
   const [page, setPage] = React.useState<number>(1);
   const history = useHistory();
 
-  
-
   const handleTagSelect = (tag: string) => {
     if(selectedTag !== toLowerCaseHyphenSeparatedString(tag)){
       history.push(`/blog/tag/${toLowerCaseHyphenSeparatedString(tag)}`)
     }
+  };
+
+  const getPageTitle = () => {
+    return filteredData[0]?.tags.find((tag:string) => selectedTag === toLowerCaseHyphenSeparatedString(tag))
   };
 
   useEffect(() => {
@@ -105,7 +107,7 @@ const Tag: React.FC = () => {
             </Container>
           </div>
           <div className={classes.sectionDiv}>
-            <h1 className={classes.blogTitle}>{selectedTag && capitalizeTextTransform(replaceHyphenWithSpace(selectedTag))}</h1>
+            <h1 className={classes.blogTitle}>{getPageTitle()}</h1>
             <Grid container direction="row" className={classes.blogsWrapper} >
               {filteredData
                 ? filteredData

--- a/website/src/pages/Blog/Tag/index.tsx
+++ b/website/src/pages/Blog/Tag/index.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from "react";
+import useStyles from "./styles";
+import { useTranslation } from "react-i18next";
+import {
+  Container,
+  Grid
+} from "@material-ui/core";
+import Footer from "../../../components/Footer";
+import { METADATA_TYPES } from "../../../constants";
+import Sponsor from "../../../components/Sponsor";
+import Pagination from "@material-ui/lab/Pagination";
+import { pageCount } from "../../../utils/getPageCount";
+import SeoJson from "../../../resources/seo.json";
+import { useCurrentHost } from "../../../hooks/useCurrentHost";
+import { Metadata } from "../../../components/Metadata";
+import BlogCard from "../../../components/BlogCard";
+import { useTag } from "../../../hooks/extractBlogPath";
+import { useHistory } from "react-router-dom";
+
+interface blog { 
+  title: string;
+  author: string;
+  excerpt: string;
+  author_info: string;
+  date: string;
+  tags: Array<string>;
+  content: string;
+  id: number;
+  slug: string; 
+}
+
+const Blog: React.FC = () => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const { currentOrigin } = useCurrentHost();
+  const [filteredData, setFilteredData] = useState<blog[]>([
+    { title: "",
+      author: "",
+      excerpt: "",
+      author_info: "",
+      date: "",
+      tags: [],
+      content: "",
+      id: 0,
+      slug: "" }
+  ]);
+  const selectedTag = useTag() || '';
+  const itemsPerPage = 6;
+  const [page, setPage] = React.useState<number>(1);
+  const history = useHistory();
+
+  const fetchBlogs = async () => {
+    const { default: blogs } = await import(`../../../posts.json`);
+    const filteredData = blogs.filter(
+      (blog: blog) => blog.tags.find((tag: string) => tag.toLowerCase() === selectedTag.toLowerCase())
+    );
+    setFilteredData(filteredData);
+  };
+
+  useEffect(() => {
+    fetchBlogs();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[selectedTag]);
+
+  const scrollToTop = () => {
+    window.scrollTo(0, 0);
+  }
+
+  const changePage = (val:number = 1) => {
+    setPage(val);
+    setPage(1);
+    scrollToTop();
+  }
+
+  const pagination = () => {
+    return (
+      <Pagination
+        count={pageCount(filteredData)}
+        page={page}
+        onChange={(_event, val) => changePage(val)}
+        className={classes.pagination}
+      />
+    );
+  };
+
+  return (
+    <>
+     <Metadata title={SeoJson.pages.blog.title} description={SeoJson.pages.blog.description} url={`${currentOrigin}${SeoJson.pages.blog.url}`} image={`${currentOrigin}${SeoJson.pages.blog.image}`} isPost={false} type={METADATA_TYPES.SERIES}  />
+        <>
+          <div className={classes.root}>
+            <Container maxWidth="lg">
+              <h1 className={classes.mainText}>{t("blog.title")}</h1>
+            </Container>
+          </div>
+          <div className={classes.sectionDiv}>
+            <h1 className={classes.blogTitle}>{selectedTag}</h1>
+            <Grid container direction="row" className={classes.blogsWrapper} >
+              {filteredData
+                ? filteredData
+                    .slice((page - 1) * itemsPerPage, page * itemsPerPage)
+                    .map((elm: any) => {
+                      return (
+                        <Grid
+                          item
+                          xs={12}
+                          md={6}
+                          key={elm.id}
+                          className={classes.cardSize}
+                        >
+                          {/* Passing parameters blog(passing complete blog object), and handleTagSelect(this fuction handles the action when tag button is clicked)  */}
+                          <BlogCard blog={elm} handleTagSelect={(tag: string) => history.push(`/blog/tag/${tag}`)}></BlogCard>
+                        </Grid>
+                      );
+                    })
+                : ""}
+            </Grid>
+            {pagination()}
+          </div>
+        </>
+      <div className={classes.blogFooter}>
+          {/* Sponsor section  */}
+          <Sponsor />
+          {/* Display footer */}
+          <footer className={classes.footer}>
+            <Footer />
+          </footer>
+      </div>
+      
+    </>
+  );
+};
+export default Blog;

--- a/website/src/pages/Blog/Tag/index.tsx
+++ b/website/src/pages/Blog/Tag/index.tsx
@@ -16,6 +16,7 @@ import { Metadata } from "../../../components/Metadata";
 import BlogCard from "../../../components/BlogCard";
 import { useTag } from "../../../hooks/extractBlogPath";
 import { useHistory } from "react-router-dom";
+import { capitalizeTextTransform, toLowerCaseHyphenSeparatedString, replaceHyphenWithSpace } from "../../../utils/stringConversions";
 
 interface blogObject { 
   title: string;
@@ -52,8 +53,8 @@ const Tag: React.FC = () => {
   
 
   const handleTagSelect = (tag: string) => {
-    if(selectedTag !== tag){
-      history.push(`/blog/tag/${tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-')}`)
+    if(selectedTag !== toLowerCaseHyphenSeparatedString(tag)){
+      history.push(`/blog/tag/${toLowerCaseHyphenSeparatedString(tag)}`)
     }
   };
 
@@ -61,7 +62,7 @@ const Tag: React.FC = () => {
     const fetchBlogs = async () => {
       const { default: blogs } = await import(`../../../posts.json`);
       const filteredData = blogs.filter(
-        (blog: blogObject) => blog.tags.find((tag: string) => tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-') === selectedTag?.toLowerCase())
+        (blog: blogObject) => blog.tags.find((tag: string) => toLowerCaseHyphenSeparatedString(tag) === selectedTag?.toLowerCase())
       );
       setFilteredData(filteredData);
     };
@@ -104,7 +105,7 @@ const Tag: React.FC = () => {
             </Container>
           </div>
           <div className={classes.sectionDiv}>
-            <h1 className={classes.blogTitle}>{selectedTag}</h1>
+            <h1 className={classes.blogTitle}>{selectedTag && capitalizeTextTransform(replaceHyphenWithSpace(selectedTag))}</h1>
             <Grid container direction="row" className={classes.blogsWrapper} >
               {filteredData
                 ? filteredData

--- a/website/src/pages/Blog/Tag/styles.ts
+++ b/website/src/pages/Blog/Tag/styles.ts
@@ -59,7 +59,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   cardSize: {
     maxWidth: "480px !important",
-    paddingTop: theme.spacing(4),
+    padding: theme.spacing(2),
     [theme.breakpoints.down("md")]: {
       maxWidth: "380px !important",
     },

--- a/website/src/pages/Blog/Tag/styles.ts
+++ b/website/src/pages/Blog/Tag/styles.ts
@@ -1,0 +1,113 @@
+import { makeStyles, Theme } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    position: "relative",
+    backgroundImage: "url(/images/png/faq_background.png)",
+    textAlign: "center",
+    backgroundRepeat: "no-repeat",
+    backgroundPosition: "center top",
+    backgroundSize: "cover",
+    padding: theme.spacing(16, 5, 5),
+    [theme.breakpoints.down("xs")]: {
+      padding: theme.spacing(5, 1),
+      marginTop: theme.spacing(10),
+      backgroundImage: "url(/images/png/faq_background_mobile.png)",
+      backgroundRepeat: "no-repeat",
+      backgroundSize: "cover",
+    },
+  },
+  mainText: {
+    display: "flex",
+    flexWrap: "wrap",
+    textAlign: "center",
+    maxWidth: '670px',
+    margin: 'auto',
+    justifyContent: "center",
+    alignItems: "center",
+    fontSize: '2.625rem',
+    [theme.breakpoints.down("sm")]: {
+      fontSize: "1.5rem",
+    },
+  },
+  sectionDiv: {
+    padding: theme.spacing(3, 0),
+    width: '75%',
+    margin: 'auto',
+    [theme.breakpoints.down("md")]: {
+      padding: theme.spacing(3, 0),
+      width: '80%'
+    },
+    [theme.breakpoints.down("xs")]: {
+      padding: theme.spacing(3, 0),
+      width: '85%'
+    }
+  },
+  blogTitle: {
+    fontSize: '2.625rem',
+    fontWeight: 700,
+    textAlign: 'center',
+    [theme.breakpoints.down('xs')]: {
+      fontSize: '1.5rem',
+    },
+  },
+  blogsWrapper: {
+    justifyContent: 'space-between',
+    [theme.breakpoints.down("sm")]: {
+      justifyContent: 'center',
+    },
+  },
+  cardSize: {
+    maxWidth: "480px !important",
+    paddingTop: theme.spacing(4),
+    [theme.breakpoints.down("md")]: {
+      maxWidth: "380px !important",
+    },
+    [theme.breakpoints.down("sm")]: {
+      maxWidth: "480px",
+    },
+    [theme.breakpoints.down("xs")]: {
+      maxWidth: "90% !important",
+    },
+  },
+  title: {
+    fontSize: '1.375rem',
+    fontWeight: 700,
+    cursor: "pointer",
+    [theme.breakpoints.down("xs")]: {
+      fontSize: '1rem'
+    },
+  },
+  pagination: {
+    display: "flex",
+    justifyContent: "center",
+    paddingTop: theme.spacing(2),
+    "& .Mui-selected": {
+      color: theme.palette.text.hint,
+      background: `${theme.palette.background.paper} !important`,
+      boxShadow: '2px 0px 33px 5px rgba(70, 68, 151, 0.04)',
+      borderRadius: '8px 8px 8px 0px'
+    },
+    "& .MuiPaginationItem-root": {
+      fontWeight: "bold",
+    },
+  },
+  blogFooter: {
+    background:  'url(/images/png/blog_index_background.png)',
+    backgroundSize: 'cover',
+    backgroundRepeat: 'no-repeat',
+    [theme.breakpoints.down('xs')]: {
+      background:  'url(/images/png/blog_index_background_mobile.png)',
+      backgroundSize: 'cover',
+      backgroundRepeat: 'no-repeat',
+    },
+  },
+  footer: {
+    gridArea: "footer",
+    width: "100%",
+    position: "relative",
+    bottom: 0,
+  },
+}));
+
+export default useStyles;

--- a/website/src/pages/Blog/Tag/styles.ts
+++ b/website/src/pages/Blog/Tag/styles.ts
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   blogTitle: {
-    fontSize: '2.625rem',
+    fontSize: '2rem',
     fontWeight: 700,
     textAlign: 'center',
     [theme.breakpoints.down('xs')]: {

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -240,8 +240,8 @@ const Blog: React.FC = () => {
                           key={elm.id}
                           className={classes.cardSize}
                         >
-                          {/* Passing parameters isAuthorPage(boolean value to determine if BlogCard is called in author page or blog index page), blog(passing complete blog object), and handleTagSelect(this fuction handles the action when tag button is clicked)  */}
-                          <BlogCard isAuthorPage={false} blog={elm} handleTagSelect={handleTagSelect}></BlogCard>
+                          {/* Passing parameters blog(passing complete blog object), and handleTagSelect(this fuction handles the action when tag button is clicked)  */}
+                          <BlogCard blog={elm} handleTagSelect={handleTagSelect}></BlogCard>
                         </Grid>
                       );
                     })

--- a/website/src/pages/Blog/styles.ts
+++ b/website/src/pages/Blog/styles.ts
@@ -92,7 +92,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   blogTitle: {
-    fontSize: '2.625rem',
+    fontSize: '2rem',
     fontWeight: 700,
     textAlign: 'center',
     [theme.breakpoints.down('xs')]: {

--- a/website/src/pages/BlogPage/index.tsx
+++ b/website/src/pages/BlogPage/index.tsx
@@ -16,6 +16,7 @@ import { useHistory } from "react-router-dom";
 import { useCurrentHost } from "../../hooks/useCurrentHost";
 import { Metadata } from "../../components/Metadata";
 import ErrorPage from "../ErrorPage";
+import CustomTag from "../../components/CustomTag";
 
 const BlogPage: React.FC = () => {
   const { currentOrigin, currentLocation, currentPathname } = useCurrentHost();
@@ -120,6 +121,22 @@ const BlogPage: React.FC = () => {
     }
   };
     
+  const getTags = (tags: string[]) => {
+    return tags.map((tag: string) => (
+      <button
+        key={tag}
+        onClick={() => handleTagSelect(tag)}
+        className={classes.tagButton}
+      >
+        <CustomTag blogLabel={tag} key={tag} />
+      </button>
+    ));
+  };
+
+  const handleTagSelect = (tag: string) => {
+    history.push(`/blog/tag/${tag}`)
+  };
+
   return (
     <>
     {currentBlogDetails?.id && Boolean(currentBlogDetails?.notHasFeatureImage) && (
@@ -206,6 +223,9 @@ const BlogPage: React.FC = () => {
             <div className={classes.blogBody}>
               <BlogImage imgPath={`/images/blog/${queryBlogName}.png`} alt={currentBlogDetails?.title} className={classes.blogImg} />
               <ReactMarkdown children={currentBlogDetails?.content} />
+              <div className={classes.tagsWrapper}>
+                {getTags(currentBlogDetails?.tags)}
+              </div>
             </div>
             
           </Grid>

--- a/website/src/pages/BlogPage/index.tsx
+++ b/website/src/pages/BlogPage/index.tsx
@@ -17,6 +17,7 @@ import { useCurrentHost } from "../../hooks/useCurrentHost";
 import { Metadata } from "../../components/Metadata";
 import ErrorPage from "../ErrorPage";
 import CustomTag from "../../components/CustomTag";
+import { toLowerCaseHyphenSeparatedString } from "../../utils/stringConversions";
 
 const BlogPage: React.FC = () => {
   const { currentOrigin, currentLocation, currentPathname } = useCurrentHost();
@@ -134,7 +135,7 @@ const BlogPage: React.FC = () => {
   };
 
   const handleTagSelect = (tag: string) => {
-    history.push(`/blog/tag/${tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-')}`)
+    history.push(`/blog/tag/${toLowerCaseHyphenSeparatedString(tag)}`)
   };
 
   return (

--- a/website/src/pages/BlogPage/index.tsx
+++ b/website/src/pages/BlogPage/index.tsx
@@ -134,7 +134,7 @@ const BlogPage: React.FC = () => {
   };
 
   const handleTagSelect = (tag: string) => {
-    history.push(`/blog/tag/${tag}`)
+    history.push(`/blog/tag/${tag.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-')}`)
   };
 
   return (

--- a/website/src/pages/BlogPage/style.ts
+++ b/website/src/pages/BlogPage/style.ts
@@ -349,6 +349,16 @@ const useStyles = makeStyles((theme: Theme) => ({
       margin: theme.spacing(0, 4),
     },
   },
+  tagsWrapper: {
+    marginTop: theme.spacing(5),
+  },
+  tagButton: {
+    border: "none",
+    background: "none",
+    margin: theme.spacing(0.5, 1, 0.5, 0),
+    cursor: "pointer",
+    padding: theme.spacing(0)
+  },
   footer: {
     paddingTop: theme.spacing(8),
     background:  'url(/images/png/blog_footer_background.png)',

--- a/website/src/utils/stringConversions.ts
+++ b/website/src/utils/stringConversions.ts
@@ -2,12 +2,4 @@ const toLowerCaseHyphenSeparatedString = (text: string) => {
     return text.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-');
 }
 
-const replaceHyphenWithSpace = (text: string) => {
-    return text.replace("-", ' ');
-}
-
-const capitalizeTextTransform = (text: string) => {
-    return text.split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
-}
-
-export {toLowerCaseHyphenSeparatedString, replaceHyphenWithSpace, capitalizeTextTransform};
+export {toLowerCaseHyphenSeparatedString};

--- a/website/src/utils/stringConversions.ts
+++ b/website/src/utils/stringConversions.ts
@@ -1,0 +1,13 @@
+const toLowerCaseHyphenSeparatedString = (text: string) => {
+    return text.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-');
+}
+
+const replaceHyphenWithSpace = (text: string) => {
+    return text.replace("-", ' ');
+}
+
+const capitalizeTextTransform = (text: string) => {
+    return text.split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+}
+
+export {toLowerCaseHyphenSeparatedString, replaceHyphenWithSpace, capitalizeTextTransform};


### PR DESCRIPTION
In this PR we are 

1. Adding separate route and page for Blog tags
![screencapture-localhost-3000-blog-tag-OpenEBS-2021-08-12-19_01_37](https://user-images.githubusercontent.com/34312966/129205633-bfb9ed8b-2891-4149-9149-37f707c15939.png)

2. Displaying blog tags at the footer of the blog page
<img width="1438" alt="Screenshot 2021-08-12 at 6 54 06 PM" src="https://user-images.githubusercontent.com/34312966/129205694-7b546dc3-22a1-41a7-a56a-f171a994bd58.png">

3. Making tags clickable on the blog page, blog slider, and author page and redirecting them to the respective tag page
