### PR TITLE
event aligned to left side

### DIFF
--- a/website/src/components/EventSlider/style.ts
+++ b/website/src/components/EventSlider/style.ts
@@ -44,6 +44,9 @@ const useStyles = makeStyles((theme) => ({
         },
       },
     },
+    "& .slick-track":{
+      margin: 0
+    },
     [theme.breakpoints.down("sm")]: {
       "& div.slick-active": {
         "& + .slick-active:not(:last-child)": {


### PR DESCRIPTION
This PR will change the alignment of events in-case the slider is not present! The events will be aligned to the left

before : ![image](https://user-images.githubusercontent.com/75615087/129843653-d230427a-5a84-447e-8f3e-cb99bb06d37d.png)

after    : ![image](https://user-images.githubusercontent.com/75615087/129843574-ba0c7b69-9000-4753-ab4a-bab59fffe9e0.png)
