### PR TITLE
(docs) : adding redirect rule to the deploy preview path to /docs

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -7,3 +7,9 @@
   base = "docs/"
   publish = "/"
   command = "yarn run previewBuild"
+  
+  # adding redirect rule to change the path to /docs
+  
+  [[redirects]]
+    from = "/"
+    to = "/docs"


### PR DESCRIPTION
Adding `/docs` to the preview deploy url, by adding redirect rule to `context.deploy-preview` context.

Signed-off-by: Rakesh PR <rakesh.pr@mayadata.io>