### PR TITLE
Updating branch name and changing URL for website revamp

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: revamp-3.0
+          ref: main
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -2,7 +2,7 @@ name: ESLint
 on:
   pull_request:
     branches:
-      - revamp-3.0
+      - main
 
 jobs:
   eslint:

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -2,7 +2,7 @@ name: Sanity check
 on:
   pull_request:
     branches:
-      - revamp-3.0
+      - main
 
 jobs:
   commits_check_job:

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 
-const WEBSITE_URL = `https://gallant-pasteur-5e438c.netlify.app`;
+const WEBSITE_URL = `https://openebs.io`;
 const path = require('path');
 
 const prismCustomColors =  {
@@ -154,7 +154,7 @@ module.exports = {
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
           editUrl:
-            "https://github.com/openebs/website/edit/revamp-3.0/docs/",
+            "https://github.com/openebs/website/edit/main/docs/",
           includeCurrentVersion: true,
           versions:{
             current:{

--- a/docs/main/introduction/commercial.md
+++ b/docs/main/introduction/commercial.md
@@ -9,7 +9,7 @@ description: This is a list of third-party companies and individuals who provide
 
 OpenEBS is an independent open source project which does not endorse any company.
 
-This is a list of third-party companies and individuals who provide products or services related to OpenEBS. If you are providing commercial support for OpenEBS, please [edit this page](https://github.com/openebs/website/edit/main/docs/versioned_docs/version-2.11.0/introduction/commercial.md) to add yourself or your organization to the list.
+This is a list of third-party companies and individuals who provide products or services related to OpenEBS. If you are providing commercial support for OpenEBS, please [edit this page](https://github.com/openebs/website/edit/main/docs/main/introduction/commercial.md) to add yourself or your organization to the list.
 
 The list is provided in alphabetical order.
 

--- a/docs/main/introduction/commercial.md
+++ b/docs/main/introduction/commercial.md
@@ -9,7 +9,7 @@ description: This is a list of third-party companies and individuals who provide
 
 OpenEBS is an independent open source project which does not endorse any company.
 
-This is a list of third-party companies and individuals who provide products or services related to OpenEBS. If you are providing commercial support for OpenEBS, please [edit this page](https://github.com/openebs/website/edit/revamp-3.0/docs/versioned_docs/version-2.11.0/introduction/commercial.md) to add yourself or your organization to the list.
+This is a list of third-party companies and individuals who provide products or services related to OpenEBS. If you are providing commercial support for OpenEBS, please [edit this page](https://github.com/openebs/website/edit/main/docs/versioned_docs/version-2.11.0/introduction/commercial.md) to add yourself or your organization to the list.
 
 The list is provided in alphabetical order.
 

--- a/docs/versioned_docs/version-2.11.0/introduction/commercial.md
+++ b/docs/versioned_docs/version-2.11.0/introduction/commercial.md
@@ -9,7 +9,7 @@ description: This is a list of third-party companies and individuals who provide
 
 OpenEBS is an independent open source project which does not endorse any company.
 
-This is a list of third-party companies and individuals who provide products or services related to OpenEBS. If you are providing commercial support for OpenEBS, please [edit this page](https://github.com/openebs/website/edit/revamp-3.0/docs/versioned_docs/version-2.11.0/introduction/commercial.md) to add yourself or your organization to the list.
+This is a list of third-party companies and individuals who provide products or services related to OpenEBS. If you are providing commercial support for OpenEBS, please [edit this page](https://github.com/openebs/website/edit/main/docs/versioned_docs/version-2.11.0/introduction/commercial.md) to add yourself or your organization to the list.
 
 The list is provided in alphabetical order.
 


### PR DESCRIPTION
Signed-off-by: Pallavi-PH <pallaviph02@gmail.com>

In this PR, we are updating the following to move `revamp-3.0` changes to new branch `main` and for updating the website URLs to point to OpenEBS website once these changes are made live:

1. Change URL(Website URL) from `https://gallant-pasteur-5e438c.netlify.app` to `https://openebs.io`.  in docusaurus.config.js
2. Change editUrl from `https://github.com/openebs/website/edit/revamp-3.0/docs/` to `https://github.com/openebs/website/edit/main/docs/` in docusaurus.config.js
3. Change branch name from `revamp-3.0` to `main` in all GitHub workflows i.e., contributors.yml, eslint.yml, and sanity-check.yml
4. Change edit URL from `https://github.com/openebs/website/edit/revamp-3.0/docs/versioned_docs/version-2.11.0/introduction/commercial.md` to `https://github.com/openebs/website/edit/main/docs/versioned_docs/version-2.11.0/introduction/commercial.md` in commercial MD file of the main version docs and in version-2.11.0