### PR TITLE
chore(docs): update contributor docs to mention that DCO sign-off is mandatory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,20 @@ OpenEBS is an Apache 2.0 Licensed project and all your commits should be signed 
 * Submit a pull request to the original repository.
 
 
-## Sign your commits
+---
 
-We use the Developer Certificate of Origin (DCO) as an additional safeguard for the OpenEBS projects. This is a well established and widely used mechanism to assure that contributors have confirmed their right to license their contribution under the project's license. Please read [dcofile](https://github.com/openebs/openebs/blob/master/contribute/developer-certificate-of-origin). If you can certify it, then just add a line to every git commit message:
+### Sign your work
 
-````
+We use the Developer Certificate of Origin (DCO) as an additional safeguard for the OpenEBS project. This is a well established and widely used mechanism to assure contributors have confirmed their right to license their contribution under the project's license. Please read [developer-certificate-of-origin](https://github.com/openebs/openebs/blob/HEAD/contribute/developer-certificate-of-origin).
+
+Please certify it by just adding a line to every git commit message. Any PR with Commits which does not have DCO Signoff will not be accepted:
+
+```
   Signed-off-by: Random J Developer <random@developer.example.org>
-````
+```
 
+or use the command `git commit -s -m "commit message comes here"` to sign-off on your commits.
+
+Use your real name (sorry, no pseudonyms or anonymous contributions). If you set your `user.name` and `user.email` git configs, you can sign your commit automatically with `git commit -s`. You can also use git [aliases](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) like `git config --global alias.ci 'commit -s'`. Now you can commit with `git ci` and the commit will be signed.
+
+---


### PR DESCRIPTION
Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>
 Update contributor docs to mention that DCO sign-off is mandatory