### PR TITLE
Update localpv-device.md 

### DIFF
--- a/docs/versioned_docs/version-3.3.x/user-guides/localpv-device.md
+++ b/docs/versioned_docs/version-3.3.x/user-guides/localpv-device.md
@@ -174,8 +174,9 @@ The default Storage Class is called `openebs-device`. If the block devices are n
            value: device
          - name: FSType
            value: xfs
-         - name: BlockDeviceTag
-           value: "mongo"
+         - name: BlockDeviceSelectors
+           data:
+             openebs.io/block-device-tag: mongo
    provisioner: openebs.io/local
    reclaimPolicy: Delete
    volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
Website documentation fix

BlockDeviceTag has been changed to BlockDeviceSelectors (refer here)[https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/tutorials/device/blockdeviceselectors.md]

Updating the example StorageClass manifest with the correct syntax