### PR TITLE
fix(docs): correct typo for hostpath NodeAffnityLabels section

### DIFF
--- a/docs/main/user-guides/localpv-device.md
+++ b/docs/main/user-guides/localpv-device.md
@@ -204,7 +204,7 @@ The default Storage Class is called `openebs-device`. If the block devices are n
         openebs.io/cas-type: local
         cas.openebs.io/config: |
           - name: StorageType
-          - value: "device"
+            value: "device"
           - name: NodeAffinityLabels
             list:
               - "openebs.io/custom-node-unique-id"

--- a/docs/main/user-guides/localpv-hostpath.md
+++ b/docs/main/user-guides/localpv-hostpath.md
@@ -158,7 +158,7 @@ The default Storage Class is called `openebs-hostpath` and its `BasePath` is con
    ```
     #### (Optional) Custom Node Labelling
 
-    In Kubernetes, Device LocalPV identifies nodes using labels such as `kubernetes.io/hostname=<node-name>`. However, these default labels might not ensure each node is distinct across the entire cluster. To solve this, you can make custom labels. As an admin, you can define and set these labels when configuring a **StorageClass**. Here's a sample storage class:
+    In Kubernetes, Hostpath LocalPV identifies nodes using labels such as `kubernetes.io/hostname=<node-name>`. However, these default labels might not ensure each node is distinct across the entire cluster. To solve this, you can make custom labels. As an admin, you can define and set these labels when configuring a **StorageClass**. Here's a sample storage class:
 
     ```
     apiVersion: storage.k8s.io/v1
@@ -178,7 +178,7 @@ The default Storage Class is called `openebs-hostpath` and its `BasePath` is con
 
     ```
   :::note 
-  Using NodeAffinityLabels does not influence scheduling of the application Pod. Use kubernetes [allowedTopologies](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/tutorials/device/allowedtopologies.md) to configure scheduling options.
+  Using NodeAffinityLabels does not influence scheduling of the application Pod. Use kubernetes [allowedTopologies](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/tutorials/hostpath/allowedtopologies.md) to configure scheduling options.
   :::
 
 2. Edit `local-hostpath-sc.yaml` and update with your desired values for `metadata.name` and `cas.openebs.io/config.BasePath`.

--- a/docs/versioned_docs/version-3.8.x/user-guides/localpv-device.md
+++ b/docs/versioned_docs/version-3.8.x/user-guides/localpv-device.md
@@ -204,7 +204,7 @@ The default Storage Class is called `openebs-device`. If the block devices are n
         openebs.io/cas-type: local
         cas.openebs.io/config: |
           - name: StorageType
-          - value: "device"
+            value: "device"
           - name: NodeAffinityLabels
             list:
               - "openebs.io/custom-node-unique-id"

--- a/docs/versioned_docs/version-3.8.x/user-guides/localpv-hostpath.md
+++ b/docs/versioned_docs/version-3.8.x/user-guides/localpv-hostpath.md
@@ -158,7 +158,7 @@ The default Storage Class is called `openebs-hostpath` and its `BasePath` is con
    ```
     #### (Optional) Custom Node Labelling
 
-    In Kubernetes, Device LocalPV identifies nodes using labels such as `kubernetes.io/hostname=<node-name>`. However, these default labels might not ensure each node is distinct across the entire cluster. To solve this, you can make custom labels. As an admin, you can define and set these labels when configuring a **StorageClass**. Here's a sample storage class:
+    In Kubernetes, Hostpath LocalPV identifies nodes using labels such as `kubernetes.io/hostname=<node-name>`. However, these default labels might not ensure each node is distinct across the entire cluster. To solve this, you can make custom labels. As an admin, you can define and set these labels when configuring a **StorageClass**. Here's a sample storage class:
 
     ```
     apiVersion: storage.k8s.io/v1
@@ -169,7 +169,7 @@ The default Storage Class is called `openebs-hostpath` and its `BasePath` is con
         openebs.io/cas-type: local
         cas.openebs.io/config: |
           - name: StorageType
-          - value: "device"
+            value: "hostpath"
           - name: NodeAffinityLabels
             list:
               - "openebs.io/custom-node-unique-id"
@@ -178,7 +178,7 @@ The default Storage Class is called `openebs-hostpath` and its `BasePath` is con
 
     ```
   :::note 
-  Using NodeAffinityLabels does not influence scheduling of the application Pod. Use kubernetes [allowedTopologies](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/tutorials/device/allowedtopologies.md) to configure scheduling options.
+  Using NodeAffinityLabels does not influence scheduling of the application Pod. Use kubernetes [allowedTopologies](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/tutorials/hostpath/allowedtopologies.md) to configure scheduling options.
   :::
 
 2. Edit `local-hostpath-sc.yaml` and update with your desired values for `metadata.name` and `cas.openebs.io/config.BasePath`.


### PR DESCRIPTION
This change corrects a typo in the localpv-hostpath user-guide.