### PR TITLE
docs: Mention IPv4 requirements for jiva

### DIFF
--- a/docs/main/user-guides/jiva/jiva-prerequisites.md
+++ b/docs/main/user-guides/jiva/jiva-prerequisites.md
@@ -93,7 +93,9 @@ volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
    ```
 
-
+:::note
+Jiva currently does **not run on IPv6-only Clusters**, your pods will still need an IPv4 address. For details, have a look on the [issue](https://github.com/openebs/jiva/issues/373).
+:::
 
 ## See Also:
 


### PR DESCRIPTION
I have recently tried to run jiva on IPv6 only pods, which failed and resulted in some troubleshooting.
The requirement for IPv4 should be noted in the docs.