### PR TITLE
fixed an error in setting mount parameters

### DIFF
--- a/docs/versioned_docs/version-4.0.x/user-guides/local-storage-user-guide/local-pv-lvm/lvm-configuration.md
+++ b/docs/versioned_docs/version-4.0.x/user-guides/local-storage-user-guide/local-pv-lvm/lvm-configuration.md
@@ -185,8 +185,8 @@ provisioner: local.csi.openebs.io
 parameters:
   storage: "lvm"
   vgpattern: "lvmvg.*"
-  mountOptions:    ## Various mount options of volume can be specified here
-    - debug
+mountOptions:    ## Various mount options of volume can be specified here
+  - debug
 ```
 :::
 


### PR DESCRIPTION
Field 'mountOptions'' is under the 'parameters'' field, an error will be reported when creating a StorageClass, so this problem needs to be fixed.