### PR TITLE
feat(ga4): enabled ga4 analytics on website and docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -23,10 +23,6 @@ module.exports = {
   },
   themeConfig: {
     image: 'img/card-openebs.png',
-    gtag: {
-      trackingID: 'UA-92076314-12',
-      anonymizeIP: true,
-    },
     colorMode: {
       defaultMode: "light",
       disableSwitch: true,
@@ -43,7 +39,11 @@ module.exports = {
     },
     prism: {
       theme: Object.assign(require('prism-react-renderer/themes/github'), prismCustomColors)
-    }
+    },
+    gtag: {
+      trackingID: 'G-BNB79447GR',
+      anonymizeIP: true,
+    },
   },
   onBrokenLinks: 'log',
   customFields: {
@@ -167,6 +167,13 @@ module.exports = {
           customCss: require.resolve("./src/scss/custom.scss"),
         },
         include: ["**/*.md", "**/*.mdx"], // Extensions to include.
+      },
+    ],
+    [
+      '@docusaurus/plugin-google-gtag',
+      {
+        trackingID: 'G-BNB79447GR',
+        anonymizeIP: true,
       },
     ],
   ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.0",
     "@docusaurus/preset-classic": "2.0.0-beta.0",
-    "@docusaurus/plugin-google-gtag": "3.3.2",
+    "@docusaurus/plugin-google-gtag": "2.0.0-beta.0",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.0",
     "@docusaurus/preset-classic": "2.0.0-beta.0",
+    "@docusaurus/plugin-google-gtag": "3.3.2",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BNB79447GR"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-BNB79447GR');
+    </script>
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://www.googletagmanager.com/ https://www.google-analytics.com/ https://static.hotjar.com/ https://script.hotjar.com/ http://adpxl.co/SyscD5JI/ https://slack.k8s.io/ http://s7.addthis.com/ https://z.moatads.com/ https://v1.addthisedge.com/ https://m.addthis.com/ wss://slack.k8s.io/ https://d33wubrfki0l68.cloudfront.net/ https://netlify-cdp-loader.netlify.app 'unsafe-eval' 'unsafe-inline'; style-src 'self' https://d33wubrfki0l68.cloudfront.net/ 'unsafe-inline'; object-src 'none'">
     <meta charset="utf-8" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/website/src/index.tsx
+++ b/website/src/index.tsx
@@ -7,7 +7,7 @@ import './i18n';
 import Loader from './components/Loader';
 
 const tagManagerArgs = {
-  gtmId: 'GTM-KD8TCG4',
+  gtmId: 'GTM-WKVV7F3N',
 };
 
 window.onload = () => {


### PR DESCRIPTION
- Adds the gtag enabling script in website head.
- Integrates the docusaurus google tag plugin in docs.
- Integrates the new google tag manager to website on the react-gtm module. 