### PR TITLE
Fix wrong PodSecurity config

### DIFF
--- a/docs/main/Solutioning/openebs-on-kubernetes-platforms/talos.md
+++ b/docs/main/Solutioning/openebs-on-kubernetes-platforms/talos.md
@@ -28,9 +28,9 @@ By default, Talos Linux applies a baseline pod security profile across namespace
   value:
     - name: PodSecurity
       configuration:
-        exemptions: null
-        namespaces:
-          - mayastor
+        exemptions:
+          namespaces:
+            - mayastor # or whatever namespace you install OpenEBS under
 ```
 
 ## Talos Worker Node Changes


### PR DESCRIPTION
`namespaces` should be a key inside of `exemptions`.

You can check the provided configuration in the official Kubernetes documentation:
https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/