### PR TITLE
Update example in rs-configuration.md

### DIFF
--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-configuration.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-configuration.md
@@ -64,7 +64,7 @@ metadata:
   namespace: openebs
 spec:
   node: workernode-1-hostname
-  disks: ["/dev/disk/by-id/<id>"]
+  disks: ["aio:///dev/disk/by-id/<id>"]
 EOF
 ```
 
@@ -83,7 +83,7 @@ metadata:
   namespace: openebs
 spec:
   node: workernode-1-hostname
-  disks: ["/dev/disk/by-id/<id>"]
+  disks: ["aio:///dev/disk/by-id/<id>"]
   topology:
     labelled:
       topology-key: topology-value

--- a/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-configuration.md
+++ b/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-configuration.md
@@ -64,7 +64,7 @@ metadata:
   namespace: openebs
 spec:
   node: workernode-1-hostname
-  disks: ["/dev/disk/by-id/<id>"]
+  disks: ["aio:///dev/disk/by-id/<id>"]
 EOF
 ```
 
@@ -83,7 +83,7 @@ metadata:
   namespace: openebs
 spec:
   node: workernode-1-hostname
-  disks: ["/dev/disk/by-id/<id>"]
+  disks: ["aio:///dev/disk/by-id/<id>"]
   topology:
     labelled:
       topology-key: topology-value


### PR DESCRIPTION
summary:
Align example with best practices - use "aio:///dev..." instead of "/dev/..."

Background:
In preparation of experimenting with OpenEBS on a home cluster I'm reading the docs. It seems to me that the 'best practice'  in the table at the end of https://openebs.io/docs/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-configuration#create-diskpools does not align with the subsequent example config. The best practice apparently is to prepend the device by `aio:///`, but in the example this is not done.
_I don't know _why_ the aio:/// or uring:/// is better so perhaps someone more knowledgable (e.g. the reviewer of this PR? :-) could add that to the docs._ 

If I understand the docs correctly, the example should be updated as I have done here. If this is wrong, the docs are unclear on this point and need some further clarification in my opinion.

> Disk(non PCI) with disk-by-guid reference (Best Practice)	Device File	aio:///dev/disk/by-id/ OR uring:///dev/disk/by-id/

