### PR TITLE
Fixed broken link

### DIFF
--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
@@ -300,6 +300,6 @@ If you encounter issues or have a question, file a [Github issue](https://github
 
 ## See Also
 
-- [Installation](../../quickstart-guide/installation.md)
+- [Installation](../../../quickstart-guide/installation.md)
 - [Configuration](../replicated-pv-mayastor/rs-configuration.md)
 - [Deploy an Application](../replicated-pv-mayastor/rs-deployment.md)

--- a/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
+++ b/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
@@ -300,6 +300,6 @@ If you encounter issues or have a question, file a [Github issue](https://github
 
 ## See Also
 
-- [Installation](../../quickstart-guide/installation.md)
+- [Installation](../../../quickstart-guide/installation.md)
 - [Configuration](../replicated-pv-mayastor/rs-configuration.md)
 - [Deploy an Application](../replicated-pv-mayastor/rs-deployment.md)


### PR DESCRIPTION
Fixed the broken link in user guides on Mayastor-installation page

on this page:
https://openebs.io/docs/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation

referenced to the following:
https://openebs.io/docs/user-guides/quickstart-guide/installation.md
