### PR TITLE
docs: added info. regarding nvme_core.multipath

### DIFF
--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/HA.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/HA.md
@@ -19,6 +19,12 @@ The HA node agent looks for I/O path failures from applications to their corresp
 The volume's replica count must be higher than one for a new target to be established as part of switch-over.
 :::
 
+To ensure optimal HA in Replicated PV Mayastor clusters:
+
+- Applications constrained to nodes with the `io-engine label` (`openebs.io/engine=mayastor`) will have the Nexus preferably placed on the same node where the application is scheduled. If the `io-engine` pod on a node is in a bad state, the Nexus may be placed on a different node.
+
+- The kernel parameter `nvme_core.multipath=Y` is mandatory to enable HA functionality. Without this configuration, failover to a new Nexus cannot be achieved effectively.
+
 ### How do I disable this feature? 
 
 :::info

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/HA.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/HA.md
@@ -23,7 +23,7 @@ To ensure optimal HA in Replicated PV Mayastor clusters:
 
 - Applications constrained to nodes with the `io-engine label` (`openebs.io/engine=mayastor`) will have the Nexus preferably placed on the same node where the application is scheduled. If the `io-engine` pod on a node is in a bad state, the Nexus may be placed on a different node.
 
-- The kernel parameter `nvme_core.multipath=Y` is mandatory to enable HA functionality. Without this configuration, failover to a new Nexus cannot be achieved effectively.
+- The kernel parameter `nvme_core.multipath=Y` is mandatory to enable HA functionality. Without this configuration, volume target failover is not possible.
 
 ### How do I disable this feature? 
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
@@ -34,7 +34,7 @@ All worker nodes must satisfy the following requirements:
 * Enabling `nvme_core.multipath` is required for High Availability (HA) functionality in Replicated PV Mayastor. Ensure the kernel parameter `nvme_core.multipath=Y` is set during the installation. (This prerequisite is optional.)
 
 :::note
-If the application is constrained to nodes with the `io-engine label` (`openebs.io/engine=mayastor`), the Nexus is preferably placed on the same node where the application is scheduled.
+If the application is scheduled to nodes with the `io-engine label` (`openebs.io/engine=mayastor`), the volume target is preferably placed on the same node where the application is scheduled.
 :::
 
 ### Network Requirements

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
@@ -31,6 +31,12 @@ All worker nodes must satisfy the following requirements:
   * **HugePage support**
     * A minimum of **2GiB of** **2MiB-sized** pages
 
+* Enabling `nvme_core.multipath` is required for High Availability (HA) functionality in Replicated PV Mayastor. Ensure the kernel parameter `nvme_core.multipath=Y` is set during the installation. (This prerequisite is optional.)
+
+:::note
+If the application is constrained to nodes with the `io-engine label` (`openebs.io/engine=mayastor`), the Nexus is preferably placed on the same node where the application is scheduled.
+:::
+
 ### Network Requirements
 
 * Ensure that the following ports are **not** in use on the node:

--- a/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/HA.md
+++ b/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/HA.md
@@ -19,6 +19,12 @@ The HA node agent looks for I/O path failures from applications to their corresp
 The volume's replica count must be higher than one for a new target to be established as part of switch-over.
 :::
 
+To ensure optimal HA in Replicated PV Mayastor clusters:
+
+- Applications constrained to nodes with the `io-engine label` (`openebs.io/engine=mayastor`) will have the Nexus preferably placed on the same node where the application is scheduled. If the `io-engine` pod on a node is in a bad state, the Nexus may be placed on a different node.
+
+- The kernel parameter `nvme_core.multipath=Y` is mandatory to enable HA functionality. Without this configuration, failover to a new Nexus cannot be achieved effectively.
+
 ### How do I disable this feature? 
 
 :::info

--- a/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/HA.md
+++ b/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/HA.md
@@ -23,7 +23,7 @@ To ensure optimal HA in Replicated PV Mayastor clusters:
 
 - Applications constrained to nodes with the `io-engine label` (`openebs.io/engine=mayastor`) will have the Nexus preferably placed on the same node where the application is scheduled. If the `io-engine` pod on a node is in a bad state, the Nexus may be placed on a different node.
 
-- The kernel parameter `nvme_core.multipath=Y` is mandatory to enable HA functionality. Without this configuration, failover to a new Nexus cannot be achieved effectively.
+- The kernel parameter `nvme_core.multipath=Y` is mandatory to enable HA functionality. Without this configuration, volume target failover is not possible.
 
 ### How do I disable this feature? 
 

--- a/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
+++ b/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
@@ -34,7 +34,7 @@ All worker nodes must satisfy the following requirements:
 * Enabling `nvme_core.multipath` is required for High Availability (HA) functionality in Replicated PV Mayastor. Ensure the kernel parameter `nvme_core.multipath=Y` is set during the installation. (This prerequisite is optional.)
 
 :::note
-If the application is constrained to nodes with the `io-engine label` (`openebs.io/engine=mayastor`), the Nexus is preferably placed on the same node where the application is scheduled.
+If the application is scheduled to nodes with the `io-engine label` (`openebs.io/engine=mayastor`), the volume target is preferably placed on the same node where the application is scheduled.
 :::
 
 ### Network Requirements

--- a/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
+++ b/docs/versioned_docs/version-4.1.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/rs-installation.md
@@ -31,6 +31,12 @@ All worker nodes must satisfy the following requirements:
   * **HugePage support**
     * A minimum of **2GiB of** **2MiB-sized** pages
 
+* Enabling `nvme_core.multipath` is required for High Availability (HA) functionality in Replicated PV Mayastor. Ensure the kernel parameter `nvme_core.multipath=Y` is set during the installation. (This prerequisite is optional.)
+
+:::note
+If the application is constrained to nodes with the `io-engine label` (`openebs.io/engine=mayastor`), the Nexus is preferably placed on the same node where the application is scheduled.
+:::
+
 ### Network Requirements
 
 * Ensure that the following ports are **not** in use on the node:


### PR DESCRIPTION
Added information about nvme_core.multipath as an optional prerequisite in the Replicated PV Mayastor Installation documentation and included it in the High Availability (HA) document.

This update explains the current behavior where, if the application is constrained to nodes with the io-engine label (openebs.io/engine=mayastor), the nexus is preferably placed on the same node as the application. Additionally, it highlights scenarios where the nexus may be placed on a different node if the io-engine pod on the preferred node is in a bad state. The use of nvme_core.multipath is emphasized as essential for enabling HA functionality.