### PR TITLE
docs: Add Known Issue and FAQ for Volume Unpublish Issue After Node Reboot

### DIFF
--- a/docs/main/faqs/faqs.md
+++ b/docs/main/faqs/faqs.md
@@ -670,6 +670,14 @@ The `mayastor/mayastor` Helm chart, along with other stable OpenEBS storage plug
 
 [Go to top](#top)
 
+### Why does a snapshot operation fail after a node reboot?
+
+If a pod-based workload is scheduled on a node that reboots and the pod does not have a controller (such as a Deployment or StatefulSet), the volume unpublish operation is not triggered. This causes the control plane to incorrectly assume that the volume is still published, even though it is not mounted. As a result, the FIFREEZE operation fails during the snapshot process, preventing the snapshot from being taken.
+
+To resolve this issue, reinstate or recreate the pod to ensure that the volume is properly mounted and recognized by the control plane.
+
+[Go to top](#top)
+
 ## See Also
 
 - [Quickstart](../quickstart-guide/installation.md)

--- a/docs/main/faqs/faqs.md
+++ b/docs/main/faqs/faqs.md
@@ -670,7 +670,7 @@ The `mayastor/mayastor` Helm chart, along with other stable OpenEBS storage plug
 
 [Go to top](#top)
 
-### Why does a snapshot operation fail after a node reboot?
+### What can cause a snapshot operation to fail sometimes after a node reboot?
 
 If a pod-based workload is scheduled on a node that reboots and the pod does not have a controller (such as a Deployment or StatefulSet), the volume unpublish operation is not triggered. This causes the control plane to incorrectly assume that the volume is still published, even though it is not mounted. As a result, the FIFREEZE operation fails during the snapshot process, preventing the snapshot from being taken.
 

--- a/docs/main/releases.md
+++ b/docs/main/releases.md
@@ -85,6 +85,8 @@ The workaround is to delete the old pod so the new pod can get scheduled. Refer 
 
 ### Watch Items and Known Issues - Replicated Storage
 
+- When a pod-based workload is scheduled on a node that reboots, and the pod lacks a controller, the volume unpublish operation is not triggered. This causes the control plane to incorrectly assume the volume is published, even though it is not mounted. As a result, FIFREEZE fails during a snapshot operation, preventing the snapshot from being taken. To resolve this, reinstate or recreate the pod to ensure the volume is properly mounted.
+
 - Replicated PV Mayastor does not support the capacity expansion of DiskPools as of v2.7.0.
 
 - The IO engine pod has been observed to restart occasionally in response to heavy IO and the constant scaling up and down of volume replicas.


### PR DESCRIPTION
Added a new Known Issue and a corresponding FAQ to address the scenario where a pod-based workload scheduled on a node that reboots does not trigger the volume unpublish operation if the pod lacks a controller. This results in the control plane incorrectly assuming the volume is published, leading to FIFREEZE failure during a snapshot operation. The issue prevents snapshots from being taken. The recommended resolution is to reinstate or recreate the pod to ensure proper volume mounting.