### PR TITLE
docs: Add Note reg. PVC Pending State When Using WaitForFirstConsumer

### DIFF
--- a/docs/main/troubleshooting/troubleshooting-local-storage.md
+++ b/docs/main/troubleshooting/troubleshooting-local-storage.md
@@ -10,13 +10,17 @@ description: This page contains a list of OpenEBS related troubleshooting which 
 
 <font size="7" color="orange">General Troubleshooting</font>
 
-### PVC in Pending state {#pvc-in-pending-state}
+### Persistent Volume Claim (PVC) in Pending state {#pvc-in-pending-state}
 
 Created a PVC using localpv-hostpath storage class. But the PV is not created and PVC in Pending state.
 
 **Troubleshooting**
 
 The default localpv storage classes from openebs have `volumeBindingMode: WaitForFirstConsumer`. This means that only when the application pod that uses the PVC is scheduled to a node, the provisioner will receive the volume provision request and will create the volume.
+
+:::note
+When utilizing the `WaitForFirstConsumer` in Kubernetes, it is imperative not to set the `nodeName` in the Pod specification to specify node affinity. Assigning `nodeName` in such scenarios bypasses the scheduler, leading to PVCs remaining in a Pending state.
+:::
 
 **Resolution**
 

--- a/docs/main/troubleshooting/troubleshooting-local-storage.md
+++ b/docs/main/troubleshooting/troubleshooting-local-storage.md
@@ -19,7 +19,8 @@ Created a PVC using localpv-hostpath storage class. But the PV is not created an
 The default localpv storage classes from openebs have `volumeBindingMode: WaitForFirstConsumer`. This means that only when the application pod that uses the PVC is scheduled to a node, the provisioner will receive the volume provision request and will create the volume.
 
 :::note
-When utilizing the `WaitForFirstConsumer` in Kubernetes, it is imperative not to set the `nodeName` in the Pod specification to specify node affinity. Assigning `nodeName` in such scenarios bypasses the scheduler, leading to PVCs remaining in a Pending state.
+If you select to use `WaitForFirstConsumer`, do not use nodeName in the Pod spec to specify node affinity. If `nodeName` is used in this case, the scheduler will be bypassed and PVC will remain in pending state.
+Instead, you can use node selector for kubernetes.io/hostname.
 :::
 
 **Resolution**


### PR DESCRIPTION
When the WaitForFirstConsumer is employed in Kubernetes, setting the nodeName field in the Pod specification can lead to Persistent Volume Claims (PVCs) remaining in a Pending state. This issue arises because specifying nodeName bypasses the scheduler, preventing proper volume binding.

A note has been added emphasizing the importance of not setting the nodeName field in the Pod specification when utilizing the WaitForFirstConsumer volume binding mode in Kubernetes.