### PR TITLE
docs: Updated the correct hyperlink for OpenEBS Releases

### DIFF
--- a/docs/main/user-guides/kubectl-openebs.md
+++ b/docs/main/user-guides/kubectl-openebs.md
@@ -25,7 +25,7 @@ By using this plugin, you get a simplified and consistent interface to manage mu
 
 ## Install Kubectl Plugin
 
-- The OpenEBS kubectl plugin is available for the Linux platform. You can download the binary from the [OpenEBS Releases](https://github.com/openebs/mayastor-control-plane/releases).
+- The OpenEBS kubectl plugin is available for the Linux platform. You can download the binary from the [OpenEBS Releases](https://github.com/openebs/openebs/releases).
 - After downloading, add the binary to your system’s $PATH.
 
 To verify the installation, run:

--- a/docs/versioned_docs/version-4.3.x/user-guides/kubectl-openebs.md
+++ b/docs/versioned_docs/version-4.3.x/user-guides/kubectl-openebs.md
@@ -25,7 +25,7 @@ By using this plugin, you get a simplified and consistent interface to manage mu
 
 ## Install Kubectl Plugin
 
-- The OpenEBS kubectl plugin is available for the Linux platform. You can download the binary from the [OpenEBS Releases](https://github.com/openebs/mayastor-control-plane/releases).
+- The OpenEBS kubectl plugin is available for the Linux platform. You can download the binary from the [OpenEBS Releases](https://github.com/openebs/openebs/releases).
 - After downloading, add the binary to your system’s $PATH.
 
 To verify the installation, run:


### PR DESCRIPTION
Updated the hyperlink for the “OpenEBS Releases” page in the [Kubectl OpenEBS Plugin document](https://openebs.io/docs/user-guides/kubectl-openebs#install-kubectl-plugin) to ensure it points to the correct location.