### PR TITLE
Dynamically set copyright year in footer

### DIFF
--- a/website/public/locale/en/translation.yaml
+++ b/website/public/locale/en/translation.yaml
@@ -31,8 +31,8 @@ footer:
   topContributors: Top contributors
   newContributors: New contributors
   contribute: Contribute
-  copyrights: Copyright © 2018-2024 The OpenEBS Authors | All rights reserved
-  cncfCopyrights: © 2024 The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our
+  copyrights: Copyright © 2018-{{year}} The OpenEBS Authors | All rights reserved
+  cncfCopyrights: © {{year}} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our
   cncfTrademark: Trademark Usage page.
   privacyPolicy: Privacy policy
 

--- a/website/src/components/Footer/index.tsx
+++ b/website/src/components/Footer/index.tsx
@@ -293,6 +293,8 @@ const Footer: React.FC = () => {
     </Toolbar>
   );
 
+  const year = new Date().getFullYear();
+
   return (
     <div className={classes.footer}>
       <hr className={classes.topDivider} />
@@ -303,7 +305,7 @@ const Footer: React.FC = () => {
 
       <div className={classes.copyrightsWrapper}>
         <Typography className={classes.copyrights}>
-          {t('footer.copyrights')}
+          {t('footer.copyrights', { year })}
         </Typography>
         <Link href="/privacy-policy" className={[classes.copyrights, classes.privacyPolicyLink].join(' ')}>
           {t('footer.privacyPolicy')}
@@ -311,7 +313,7 @@ const Footer: React.FC = () => {
       </div>
       <div className={classes.copyrightsWrapper}>
         <Typography className={classes.copyrights}>
-          {t('footer.cncfCopyrights')}
+          {t('footer.cncfCopyrights', { year })}
         </Typography>
         <Link href="https://www.linuxfoundation.org/legal/trademark-usage" className={[classes.copyrights, classes.privacyPolicyLink].join(' ')}>
           {t('footer.cncfTrademark')}


### PR DESCRIPTION
Replace hardcoded copyright years with dynamic interpolation using the current year, so the footer stays up to date automatically.