### PR TITLE
docs: create a new documents for offline pool deletion and offline node deletion

### DIFF
--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
@@ -100,7 +100,7 @@ kubectl openebs mayastor delete node node-0-469923 -n openebs --purge --show-imp
  node-0-469923      Unknown     1           1           true
 ```
 
-## Purge a Pool
+## Purge a Node
 
 Use the following command to purge an irrecoverable node from the Replicated PV Mayastor control plane.
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
@@ -123,7 +123,7 @@ If the node contains critical resources, additional confirmation flags may be re
 | Accept the data loss involved with removing all replicas that are the last healthy replicas of their respective volumes on the node | `--accept-volume-loss` |
 | Accept the data loss involved with removing all snapshot replicas that are the last remaining snapshot replicas of their respective volumes on the node. This flag can be used only together with `--accept-volume-loss`. | `--accept-snapshot-loss` |
 | Accept both volume and snapshot data loss using a single confirmation flag | `--accept-data-loss` |
-| Remove DiskPool CRs associated with the purged node | `--cleanup-dsp` |
+| Remove DiskPool CRs associated with the Pools on the Purged Node | `--cleanup-dsp` |
 | Display the expected volume and snapshot impact before performing purge | `--show-impact` |
 
 ## Data Loss Confirmation

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
@@ -96,23 +96,22 @@ kubectl openebs mayastor delete node node-0-469923 -n openebs --purge --show-imp
 **Sample Output**
 
 ```
- NODE               STATUS      REPLICAS    VOLUMES     READY
- node-0-469923      Unknown     1           1           true
+NODE               STATUS      REPLICAS    VOLUMES     READY
+node-0-469923      Unknown     1           1           true
 ```
 
 ## Purge a Node
 
 Use the following command to purge an irrecoverable node from the Replicated PV Mayastor control plane.
 
-:::note
-Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for pools associated with the purged node.
-:::
-
 **Command**
 
 ```
 kubectl openebs mayastor delete node node-0-469923 -n openebs --purge --yes --cleanup-dsp
 ```
+:::note
+Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for pools associated with the purged node.
+:::
 
 ## Purge Options
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
@@ -1,0 +1,197 @@
+---
+id: offline-node-deletion
+title: Offline Node Deletion
+keywords:
+ - Offline Node Deletion
+ - Node Deletion
+ - Purge
+description: This document explains about the Offline Node Deletion feature.
+---
+
+# Offline Node Deletion
+
+## Overview
+
+Offline node deletion, referred to as purge, allows you to remove a Replicated PV Mayastor node from the control plane when it is no longer reachable and cannot be recovered. Purge removes the node’s representation from the control plane along with associated resources that are no longer accessible on that node, without requiring communication with the underlying host.
+
+This operation is intended for failure scenarios where the node is considered irrecoverably lost and cannot be deleted through normal means that require access to the node.
+
+Typical scenarios include:
+
+- The host running the node is permanently unavailable and has been replaced
+- The node cannot be recovered due to infrastructure or hardware failure
+- Storage resources on the node are no longer accessible
+
+Purge is not part of the normal node lifecycle and should be used only when you are certain that the node cannot be recovered.
+
+:::warning
+Offline node deletion is irreversible and may result in permanent loss of access to volume or snapshot data.
+:::
+
+## When to Use Purge
+
+Use purge only when:
+
+- The node is no longer accessible and cannot be recovered
+- The host running the node is permanently unavailable
+- Storage resources on the node are lost or inaccessible
+
+Do not use purge for temporary failures or conditions where the node may become available again.
+
+**Example: Offline Node State**
+
+The following example shows a Replicated PV Mayastor node in an Offline state.
+
+**Command**
+
+```
+kubectl openebs mayastor get nodes -n openebs
+```
+
+**Sample Output**
+
+```
+ID             GRPC ENDPOINT       STATUS   VERSION                           POOLS  VOLUMES  SNAPSHOTS 
+node-0-469923  5.223.46.235:10124  Offline  v2.9.0-alpha.0-250-g36f25c282ef1  1      2        0 
+node-1-469923  5.223.44.23:10124   Online   v2.9.0-alpha.0-250-g36f25c282ef1  1      1        0 
+node-2-469923  5.223.46.36:10124   Online   v2.9.0-alpha.0-250-g36f25c282ef1  1      1        0
+```
+
+## Requirements
+
+Before performing purge, ensure that:
+
+- The node is offline
+- The node is cordoned to prevent new workloads from being scheduled. Refer to the [Cordon Node documentation](../advanced-operations/cordon-node.md) for details on how to cordon a node.
+- The `openebs.io/engine` label has been removed from the Kubernetes node.
+
+**Example: Cordon the Node**
+
+Before purge, cordon the node and remove the `openebs.io/engine` label.
+
+**Command**
+
+```
+kubectl openebs mayastor cordon node node-0-469923 openebs-offline=true -n openebs
+kubectl label node node-0-469923 openebs.io/engine-
+```
+
+**Sample Output**
+
+```
+Node node-0-469923 cordoned successfully
+node/node-0-469923 unlabeled
+```
+
+## Review Purge Impact
+
+Before performing purge, review the affected replicas and workloads.
+
+**Command**
+
+```
+kubectl openebs mayastor delete node node-0-469923 -n openebs --purge --show-impact
+```
+
+**Sample Output**
+
+```
+ NODE               STATUS      REPLICAS    VOLUMES     READY
+ node-0-469923      Unknown     1           1           true
+```
+
+## Purge a Pool
+
+Use the following command to purge an irrecoverable node from the Replicated PV Mayastor control plane.
+
+:::note
+Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for pools associated with the purged node.
+:::
+
+**Command**
+
+```
+kubectl openebs mayastor delete node node-0-469923 -n openebs --purge --yes --accept-data-loss --cleanup-dsp
+```
+
+**Sample Output**
+
+```
+NODE            VOLUME-LOSS     SNAPSHOT-LOSS 
+node-0-469923   1 volume(s)     <none>
+```
+The output reports the affected resources and confirms that the purge operation completed successfully.
+
+## Data Loss Confirmation
+
+If the node contains critical resources, additional confirmation flags may be required.
+
+| Condition | Required Flag |
+| :--- | :--- |
+| General confirmation for purge operation | `--yes` |
+| Accept the data loss involved with removing all replicas that are the last healthy replicas of their respective volumes on the node | `--accept-volume-loss` |
+| Accept the data loss involved with removing all snapshot replicas that are the last remaining snapshot replicas of their respective volumes on the node. This flag can be used only together with `--accept-volume-loss`. | `--accept-snapshot-loss` |
+| Accept both volume and snapshot data loss using a single confirmation flag | `--accept-data-loss` |
+| Remove DiskPool CRs associated with the purged node | `--cleanup-dsp` |
+| Display the expected volume and snapshot impact before performing purge | `--show-impact` |
+
+**Example: Volume Loss Confirmation**
+
+If the purge operation impacts the last healthy replica of a volume, the command returns the following message:
+
+`Volumes would lose their last healthy replica. Use --accept-volume-loss to proceed, or --accept-data-loss to also accept snapshot loss in a single flag.`
+
+To continue with the purge operation, additional confirmation is required:
+
+**Command**
+
+```
+kubectl openebs mayastor delete node node-0-469923 -n openebs --purge --yes --accept-data-loss
+```
+
+**Sample Output**
+
+```
+NODE               VOLUME-LOSS     SNAPSHOT-LOSS 
+node-0-469923      1 volume(s)     <none>
+```
+
+## Impact on Workloads
+
+- **Single-replica volumes:** Data is permanently lost if the replica resides on the purged node. 
+- **Multi-replica volumes:** Volumes may continue to operate and recover using remaining replicas if high availability (HA) is configured and sufficient replicas remain. 
+- **Snapshots:** Snapshots may become unusable if the last healthy snapshot replica was located on the purged node.
+
+**Example: Volume Replica Topology**
+
+The following example shows replica topology information before node purge.
+
+**Command**
+
+```
+kubectl openebs mayastor get volume-replica-topologies -n openebs
+```
+
+**Sample Output**
+
+```
+VOLUME-ID                             REPLICA-ID                            NODE           POOL                STATUS   ENCRYPTED  CAPACITY  ALLOCATED  SNAPSHOTS  CHILD-STATUS  REASON  REBUILD  HEALTHY 
+f373835e-4ada-4eec-a4f3-b35f1be7817b  b63e1f76-22ce-4c9f-8d3c-196b7ecb503e  node-2-469923  pool-node-2-469923  Online   false      1 GiB     1 GiB      0 B        Online        <none>  <none>   true 
+├─                                    ca275563-e044-46e3-ad60-22b5701223cb  node-0-469923  pool-node-0-469923  Unknown  false      <none>    <none>     <none>     Faulted       <none>  <none>   false 
+└─                                    ff544d71-9fa6-461a-85e6-a9e3e922d339  node-1-469923  pool-node-1-469923  Online   false      1 GiB     1 GiB      0 B        Online        <none>  <none>   true 
+ec307c1d-3311-4768-9a60-eb457b84277d  2961803b-01c2-49bf-b8bf-c6014f336f96  node-0-469923  pool-node-0-469923  Unknown  false      <none>    <none>     <none>     <none>        <none>  <none>   true
+```
+
+## Verify Purge Completion
+
+After performing purge, verify that the node has been removed and that affected workloads reflect the updated state.
+
+```
+kubectl openebs mayastor get nodes
+```
+
+**Expected Results**
+
+- The purged node is no longer listed.
+- Associated pools are no longer listed.
+- Affected workloads reflect updated states.

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion.md
@@ -111,18 +111,10 @@ Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for pools associat
 **Command**
 
 ```
-kubectl openebs mayastor delete node node-0-469923 -n openebs --purge --yes --accept-data-loss --cleanup-dsp
+kubectl openebs mayastor delete node node-0-469923 -n openebs --purge --yes --cleanup-dsp
 ```
 
-**Sample Output**
-
-```
-NODE            VOLUME-LOSS     SNAPSHOT-LOSS 
-node-0-469923   1 volume(s)     <none>
-```
-The output reports the affected resources and confirms that the purge operation completed successfully.
-
-## Data Loss Confirmation
+## Purge Options
 
 If the node contains critical resources, additional confirmation flags may be required.
 
@@ -134,6 +126,8 @@ If the node contains critical resources, additional confirmation flags may be re
 | Accept both volume and snapshot data loss using a single confirmation flag | `--accept-data-loss` |
 | Remove DiskPool CRs associated with the purged node | `--cleanup-dsp` |
 | Display the expected volume and snapshot impact before performing purge | `--show-impact` |
+
+## Data Loss Confirmation
 
 **Example: Volume Loss Confirmation**
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
@@ -1,0 +1,227 @@
+---
+id: offline-pool-deletion
+title: Offline Pool Deletion
+keywords:
+ - Offline Pool Deletion
+ - Pool Deletion
+ - Purge
+description: This document explains about the Offline Pool Deletion feature.
+---
+
+# Offline Pool Deletion
+
+## Overview
+
+Offline pool deletion, referred to as purge, allows you to remove a storage pool (pool) from the Replicated PV Mayastor control plane when it is no longer reachable and cannot be recovered. Purge removes the pool’s representation from the control plane without deleting any data that may still exist on the underlying storage device.
+
+This operation is intended for failure scenarios where the pool is considered irrecoverably lost and cannot be deleted through normal means that require access to the underlying storage.
+
+Typical scenarios include:
+
+- The host running the pool is permanently unavailable and has been replaced
+- The underlying storage device is no longer accessible
+- The pool cannot be recovered due to infrastructure or hardware failure
+
+Purge is not part of the normal pool lifecycle and should be used only when you are certain that the pool cannot be recovered.
+
+:::warning
+Offline pool deletion is irreversible and may result in permanent volume data or snapshot data loss.
+:::
+
+## When to Use Purge
+
+Use purge only when:
+
+- The pool is no longer accessible and cannot be recovered
+- The host running the pool is permanently unavailable
+- The underlying storage device is lost or inaccessible
+
+Do not use purge for temporary failures or conditions where the pool may become available again.
+
+**Example: Offline Pool State**
+
+The following example shows a pool in an Offline state because the hosting node is unavailable.
+
+**Command**
+
+```
+kubectl openebs mayastor get pools -n openebs
+```
+
+**Sample Output**
+
+```
+ID                  DISKS                                            MANAGED  NODE           STATUS                   ALERTS   CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  ENCRYPTED  DISK-CAPACITY  MAX-EXPANDABLE-SIZE  VOLUMES  SNAPSHOTS 
+pool-node-0-469894  aio:///dev/disk/by-id/scsi-0HC_Volume_105758064  true     node-0-469894  Online                   Healthy  10 GiB    4 GiB      6 GiB      4 GiB      false      10 GiB         127.8 GiB            1        0 
+pool-node-1-469894  /dev/disk/by-id/scsi-0HC_Volume_105758065        true     node-1-469894  Offline (NodeIsOffline)  <none>   0 B       0 B        0 B        <none>     false      <none>         <none>               2        0 
+pool-node-2-469894  aio:///dev/disk/by-id/scsi-SHC_Volume_105758063  true     node-2-469894  Online                   Healthy  10 GiB    4 GiB      6 GiB      4 GiB      false      10 GiB         127.8 GiB            1        0
+```
+
+## Requirements
+
+Before performing purge, ensure that the pool is cordoned to prevent any new replicas or snapshots from being scheduled on it.
+
+Refer to the [Pool Cordon documentation](../advanced-operations/cordon-pools.md) for details on how to cordon a pool.
+
+**Example: Cordon the Pool**
+
+Before purge, cordon the pool to prevent new replicas or snapshots from being scheduled.
+
+**Command**
+
+```
+kubectl openebs mayastor cordon pool pool-node-1-469894 -n openebs --replicas --snapshots
+```
+
+**Sample Output**
+
+```
+Pool pool-node-1-469894 cordoned successfully. Current constraints: replicas,snapshots
+```
+
+## Review Purge Impact
+
+Before performing purge, review the affected replicas and volumes.
+
+**Command**
+
+```
+kubectl openebs mayastor delete pool <pool-id> -n openebs --show-impact
+```
+
+**Sample Output**
+
+```
+POOL                STATUS   CORDON  REPLICAS  VOLUMES                               READY 
+pool-node-1-469894  Unknown  Ready   1         86598b37-4a37-4a85-a014-4f5e5022bb4e  true
+```
+
+## Purge a Pool
+
+Use the following command to purge an irrecoverable pool from the Replicated PV Mayastor control plane.
+
+**Command**
+
+```
+kubectl openebs mayastor delete pool <pool-id> --purge --yes
+```
+
+**Sample Command**
+
+```
+kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes --accept-data-loss
+```
+
+**Sample Output**
+
+```
+ POOL                VOLUME-LOSS  SNAPSHOT-LOSS 
+ pool-node-1-469894  1 volume(s)  <none>
+```
+
+## Data Loss Confirmation
+
+If the pool contains critical data, additional confirmation is required:
+
+| Condition | Required Flag |
+| :--- | :--- |
+| Pool contains replicas | `--yes` |
+| Last replica of a volume | `--accept-volume-loss` |
+| Last snapshot replica | `--accept-snapshot-loss` |
+
+**Example: Volume Loss Confirmation**
+
+If the purge operation impacts the last healthy replica of a volume, the command requires additional confirmation.
+
+**Command**
+
+```
+kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes
+```
+
+**Sample Output**
+
+```
+Volumes would lose their last healthy replica. Use --accept-volume-loss to proceed, or --accept-data-loss to also accept snapshot loss in a single flag.
+```
+
+**Example: Accept Data Loss**
+
+The following example confirms volume or snapshot data loss and proceeds with purge.
+
+**Command**
+
+```
+kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes --accept-data-loss
+```
+
+**Sample Output**
+
+```
+POOL                VOLUME-LOSS  SNAPSHOT-LOSS 
+pool-node-1-469894  1 volume(s)  <none>
+```
+
+## Impact on Workloads
+Single-replica volumes: Data is permanently lost if the replica resides on the purged pool.
+
+Multi-replica volumes: Volumes may continue to operate and recover using remaining replicas if high availability (HA) is configured and sufficient replicas remain.
+
+**Example: Workloads Using the Affected Pool**
+
+The following example shows workloads and PVCs associated with single-replica and multi-replica volumes.
+
+**Command**
+
+```
+kubectl get pod,pvc -o wide
+```
+
+**Sample Output**
+
+```
+NAME                         READY   STATUS    RESTARTS   AGE     IP            NODE            NOMINATED NODE   READINESS GATES
+pod/busybox-single-replica   1/1     Running   0          18m     10.244.2.9    node-1-469894   <none>           <none>
+pod/busybox-three-replica    1/1     Running   0          9m27s   10.244.1.11   node-0-469894   <none>           <none>
+
+NAME                                                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             VOLUMEATTRIBUTESCLASS   AGE     VOLUMEMODE
+persistentvolumeclaim/mayastor-vol-single-replica   Bound    pvc-86598b37-4a37-4a85-a014-4f5e5022bb4e   4Gi        RWO            openebs-single-replica   <unset>                 18m     Filesystem
+persistentvolumeclaim/mayastor-vol-three-replica    Bound    pvc-37ba6b83-3295-4522-8cc5-c0c0755b08b3   4Gi        RWO            openebs-three-replica    <unset>                 9m28s   Filesystem
+```
+
+**Example: Volume Replica Topology**
+
+The following example shows replica topology information for single-replica and multi-replica volumes before purge.
+
+**Command**
+
+```
+kubectl openebs mayastor get volume-replica-topologies -n openebs
+```
+
+**Sample Output**
+
+```
+VOLUME-ID                             REPLICA-ID                            NODE           POOL                STATUS   ENCRYPTED  CAPACITY  ALLOCATED  SNAPSHOTS  CHILD-STATUS  REASON  REBUILD  HEALTHY 
+86598b37-4a37-4a85-a014-4f5e5022bb4e  4b019a21-e3b3-4fd0-bcc3-e79ff15d3a04  node-1-469894  pool-node-1-469894  Unknown  false      <none>    <none>     <none>     <none>        <none>  <none>   true 
+37ba6b83-3295-4522-8cc5-c0c0755b08b3  53f1eca1-f4ee-4288-adb4-e41592e7fc5f  node-2-469894  pool-node-2-469894  Online   false      4 GiB     4 GiB      0 B        Online        <none>  <none>   true 
+├─                                    76e3f67b-7139-4723-8438-d69a57014be8  node-0-469894  pool-node-0-469894  Online   false      4 GiB     4 GiB      0 B        Online        <none>  <none>   true 
+└─                                    b4e1c87e-5868-4c32-8924-11ef0e44c59e  node-1-469894  pool-node-1-469894  Unknown  false      <none>    <none>     <none>     Faulted       <none>  <none>   false
+```
+
+## Verify Purge Completion
+After performing purge, verify that the pool has been removed and that affected workloads reflect the updated state.
+
+```
+kubectl openebs mayastor get pools
+```
+
+**Expected Results**
+
+- The pool should no longer appear 
+- Affected volumes may show updated states 
+
+## Troubleshooting
+- Ensure the pool is cordoned correctly
+- Ensure snapshot scheduling is blocked
+- Verify the pool is not in an active state

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
@@ -100,24 +100,23 @@ pool-node-1-469894  Unknown  Ready   1         86598b37-4a37-4a85-a014-4f5e5022b
 
 Use the following command to purge an irrecoverable pool from the Replicated PV Mayastor control plane.
 
+:::note
+Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for pools associated with the purged node.
+:::
+
 **Command**
 
 ```
-kubectl openebs mayastor delete pool <pool-id> --purge --yes
-```
-
-**Sample Command**
-
-```
-kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes --accept-data-loss
+kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes --accept-data-loss --cleanup-dsp
 ```
 
 **Sample Output**
 
 ```
- POOL                VOLUME-LOSS  SNAPSHOT-LOSS 
- pool-node-1-469894  1 volume(s)  <none>
+ POOL                   VOLUME-LOSS     SNAPSHOT-LOSS 
+ pool-node-1-469894     1 volume(s)     <none>
 ```
+The output reports the affected resources and confirms that the purge operation completed successfully.
 
 ## Data Loss Confirmation
 
@@ -125,18 +124,25 @@ If the pool contains critical data, additional confirmation is required:
 
 | Condition | Required Flag |
 | :--- | :--- |
-| Pool contains replicas | `--yes` |
-| Last replica of a volume | `--accept-volume-loss` |
-| Last snapshot replica | `--accept-snapshot-loss` |
+| General confirmation for purge operation | `--yes` |
+| Accept the data loss involved with removing all replicas that are the last healthy replicas of their respective volumes on the pool | `--accept-volume-loss` |
+| Accept the data loss involved with removing all snapshot replicas that are the last remaining snapshot replicas of their respective volumes on the pool. This flag can be used only together with `--accept-volume-loss`. | `--accept-snapshot-loss` |
+| Accept both volume and snapshot data loss using a single confirmation flag | `--accept-data-loss` |
+| Remove DiskPool CRs associated with the purged pool | `--cleanup-dsp` |
+| Display the expected volume and snapshot impact before performing purge | `--show-impact` |
 
 **Example: Volume Loss Confirmation**
 
-If the purge operation impacts the last healthy replica of a volume, the command requires additional confirmation.
+If the purge operation impacts the last healthy replica of a volume, the command returns the following message:
+
+`Volumes would lose their last healthy replica. Use --accept-volume-loss to proceed, or --accept-data-loss to also accept snapshot loss in a single flag.`
+
+To continue with the purge operation, additional confirmation is required:
 
 **Command**
 
 ```
-kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes
+kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes --accept-data-loss
 ```
 
 **Sample Output**
@@ -163,6 +169,7 @@ pool-node-1-469894  1 volume(s)  <none>
 ```
 
 ## Impact on Workloads
+
 Single-replica volumes: Data is permanently lost if the replica resides on the purged pool.
 
 Multi-replica volumes: Volumes may continue to operate and recover using remaining replicas if high availability (HA) is configured and sufficient replicas remain.
@@ -210,6 +217,7 @@ VOLUME-ID                             REPLICA-ID                            NODE
 ```
 
 ## Verify Purge Completion
+
 After performing purge, verify that the pool has been removed and that affected workloads reflect the updated state.
 
 ```

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
@@ -100,15 +100,15 @@ pool-node-1-469894  Unknown  Ready   1         86598b37-4a37-4a85-a014-4f5e5022b
 
 Use the following command to purge an irrecoverable pool from the Replicated PV Mayastor control plane.
 
-:::note
-Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for the purged pool.
-:::
-
 **Command**
 
 ```
 kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes --cleanup-dsp
 ```
+
+:::note
+Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for the purged pool.
+:::
 
 ## Purge Options
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
@@ -107,18 +107,10 @@ Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for the purged poo
 **Command**
 
 ```
-kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes --accept-data-loss --cleanup-dsp
+kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes --cleanup-dsp
 ```
 
-**Sample Output**
-
-```
-POOL                   VOLUME-LOSS     SNAPSHOT-LOSS 
-pool-node-1-469894     1 volume(s)     <none>
-```
-The output reports the affected resources and confirms that the purge operation completed successfully.
-
-## Data Loss Confirmation
+## Purge Options
 
 If the pool contains critical data, additional confirmation is required:
 
@@ -130,6 +122,8 @@ If the pool contains critical data, additional confirmation is required:
 | Accept both volume and snapshot data loss using a single confirmation flag | `--accept-data-loss` |
 | Remove DiskPool CRs associated with the purged pool | `--cleanup-dsp` |
 | Display the expected volume and snapshot impact before performing purge | `--show-impact` |
+
+## Data Loss Confirmation
 
 **Example: Volume Loss Confirmation**
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
@@ -12,7 +12,7 @@ description: This document explains about the Offline Pool Deletion feature.
 
 ## Overview
 
-Offline pool deletion, referred to as purge, allows you to remove a storage pool (pool) from the Replicated PV Mayastor control plane when it is no longer reachable and cannot be recovered. Purge removes the pool’s representation from the control plane without deleting any data that may still exist on the underlying storage device.
+Offline pool deletion, referred to as purge, allows you to remove a storage pool (pool) from the Replicated PV Mayastor control plane when it is no longer reachable and cannot be recovered. Purge removes the pool’s representation from the control plane without attempting to erase any data that may still exist on the underlying storage device.
 
 This operation is intended for failure scenarios where the pool is considered irrecoverably lost and cannot be deleted through normal means that require access to the underlying storage.
 
@@ -25,7 +25,7 @@ Typical scenarios include:
 Purge is not part of the normal pool lifecycle and should be used only when you are certain that the pool cannot be recovered.
 
 :::warning
-Offline pool deletion is irreversible and may result in permanent volume data or snapshot data loss.
+Offline pool deletion is irreversible and may result in permanent loss of access to volume or snapshot data if the purged pool contains the last healthy replicas.
 :::
 
 ## When to Use Purge
@@ -220,8 +220,3 @@ kubectl openebs mayastor get pools
 
 - The pool should no longer appear 
 - Affected volumes may show updated states 
-
-## Troubleshooting
-- Ensure the pool is cordoned correctly
-- Ensure snapshot scheduling is blocked
-- Verify the pool is not in an active state

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
@@ -113,8 +113,8 @@ kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes
 **Sample Output**
 
 ```
- POOL                   VOLUME-LOSS     SNAPSHOT-LOSS 
- pool-node-1-469894     1 volume(s)     <none>
+POOL                   VOLUME-LOSS     SNAPSHOT-LOSS 
+pool-node-1-469894     1 volume(s)     <none>
 ```
 The output reports the affected resources and confirms that the purge operation completed successfully.
 
@@ -148,7 +148,8 @@ kubectl openebs mayastor delete pool pool-node-1-469894 -n openebs --purge --yes
 **Sample Output**
 
 ```
-Volumes would lose their last healthy replica. Use --accept-volume-loss to proceed, or --accept-data-loss to also accept snapshot loss in a single flag.
+NODE               VOLUME-LOSS     SNAPSHOT-LOSS 
+node-0-469923      1 volume(s)     <none>
 ```
 
 **Example: Accept Data Loss**
@@ -170,9 +171,8 @@ pool-node-1-469894  1 volume(s)  <none>
 
 ## Impact on Workloads
 
-Single-replica volumes: Data is permanently lost if the replica resides on the purged pool.
-
-Multi-replica volumes: Volumes may continue to operate and recover using remaining replicas if high availability (HA) is configured and sufficient replicas remain.
+- **Single-replica volumes:** Data is permanently lost if the replica resides on the purged pool.
+- **Multi-replica volumes:** Volumes may continue to operate and recover using remaining replicas if high availability (HA) is configured and sufficient replicas remain.
 
 **Example: Workloads Using the Affected Pool**
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion.md
@@ -101,7 +101,7 @@ pool-node-1-469894  Unknown  Ready   1         86598b37-4a37-4a85-a014-4f5e5022b
 Use the following command to purge an irrecoverable pool from the Replicated PV Mayastor control plane.
 
 :::note
-Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for pools associated with the purged node.
+Use `--cleanup-dsp` to remove DiskPool custom resources (CRs) for the purged pool.
 :::
 
 **Command**

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -570,6 +570,11 @@ const sidebars: SidebarsConfig =
                     },
                     {
                       type: "doc",
+                      id: "user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-node-deletion",
+                      label: "Offline Node Deletion"
+                    },
+                    {
+                      type: "doc",
                       id: "user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/volume-snapshots",
                       label: "Volume Snapshots"
                     },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -565,6 +565,11 @@ const sidebars: SidebarsConfig =
                     },
                     {
                       type: "doc",
+                      id: "user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/offline-pool-deletion",
+                      label: "Offline Pool Deletion"
+                    },
+                    {
+                      type: "doc",
                       id: "user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/volume-snapshots",
                       label: "Volume Snapshots"
                     },


### PR DESCRIPTION
Create user-facing documentations for the Offline Node Deletion (Purge) and Offline Pool Deletion features in Replicated PV Mayastor.

Offline Pool Deletion document covers:
- Overview
- When to Use Purge
- Requirements
- Review Purge Impact
- Purge a Pool
- Data Loss Confirmation
- Impact on Workloads
- Verify Purge Completion

Offline Node Deletion document covers:- Overview
- When to Use Purge
- Requirements
- Review Purge Impact
- Purge a Node
- Data Loss Confirmation
- Impact on Workloads
- Verify Purge Completion