### PR TITLE
docs: update kubevirt doc as per openebs doc style & create diskpool doc with maxexpansion details

### DIFF
--- a/docs/main/Solutioning/kubevirt.md
+++ b/docs/main/Solutioning/kubevirt.md
@@ -13,25 +13,32 @@ description: Learn how to test the experimental native RWX block volume support 
 
 ## Overview
 
-Replicated PV Mayastor has **experimental** native support for RWX (ReadWriteMany) **block** volumes, specifically designed to enable KubeVirt VM live migration without an NFS intermediary. This allows two KubeVirt nodes to hold concurrent NVMe-oF connections to the same volume while the migration is in progress.
+Replicated PV Mayastor provides experimental support for native ReadWriteMany (RWX) block volumes to enable KubeVirt Virtual Machine (VM) live migration without requiring an intermediary NFS layer.
 
-This guide helps you test the workflow and provide feedback to the OpenEBS team.
+This capability allows multiple KubeVirt nodes to maintain concurrent access to the same block volume during migration, enabling VM workloads to move between nodes while preserving storage access.
 
-For design details, see:
-- [OEP: RWX Block Volume Support in Mayastor for KubeVirt](https://github.com/openebs/openebs/blob/develop/designs/replicated-pv/mayastor/rwx-kubevirt.md)
+This document describes how to deploy, validate, and evaluate the experimental native ReadWriteMany (RWX) block volume support for KubeVirt live migration. It also provides guidance for testing the feature and submitting feedback to the OpenEBS team.
+
+Refer [OEP: RWX Block Volume Support in Replicated PV Mayastor for KubeVirt](https://github.com/openebs/openebs/blob/develop/designs/replicated-pv/mayastor/rwx-kubevirt.md) for design/implementation details.
 
 :::warning Experimental feature
 This feature is experimental and should be evaluated in non-production environments only. Feedback is actively requested so the team can harden the implementation before it becomes generally available.
 :::
 
-## Scope and constraints
+## Scope and Limitations
+
+This feature is currently intended for evaluating KubeVirt VM live migration using native RWX block volumes.
+
+The following limitations apply:
 
 - Intended for **KubeVirt** VM live migration use cases only.
 - Only **block** mode volumes are supported (`volumeMode: Block`).
 - `ReadWriteMany` for **filesystem** mode volumes is not supported by this mechanism.
 - Complex network-fault scenarios during migration have known gaps (see [Known limitation](#known-limitation)).
 
-## Environment used for validation
+## Validated Environment
+
+The procedures in this document were validated using the following software versions:
 
 | Component | Version |
 | :--- | :--- |
@@ -42,12 +49,19 @@ This feature is experimental and should be evaluated in non-production environme
 
 ## Prerequisites
 
-- OpenEBS Replicated PV Mayastor installed and healthy. Refer to the [OpenEBS Installation Documentation](../../quickstart-guide/installation.md).
-- At least 3 worker nodes for migration testing.
+Before proceeding, ensure that:
+
+- OpenEBS Replicated PV Mayastor is installed and healthy.
+- At least three worker nodes are available for migration testing.
+- A healthy Replicated PV Mayastor storage cluster is configured.
+
+Refer to the [OpenEBS Installation Documentation](../../quickstart-guide/installation.md) for installation instructions.
 
 ## Install KubeVirt
 
 1. Install the KubeVirt Operator.
+
+  **Command** 
 
    ```bash
    export VERSION=$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
@@ -55,7 +69,7 @@ This feature is experimental and should be evaluated in non-production environme
    kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-operator.yaml"
    ```
 
-   **Sample output**
+   **Sample Output**
    ```
    namespace/kubevirt created
    customresourcedefinition.apiextensions.k8s.io/kubevirts.kubevirt.io created
@@ -69,19 +83,23 @@ This feature is experimental and should be evaluated in non-production environme
    deployment.apps/virt-operator created
    ```
 
-2. Create the KubeVirt Custom Resource.
+2. Create the KubeVirt Custom Resource (CR).
 
+   **Command** 
+   
    ```bash
    kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-cr.yaml"
    ```
 
-   **Sample output**
+   **Sample Output**
    ```
    kubevirt.kubevirt.io/kubevirt created
    ```
 
 3. (Optional) Enable emulation if hardware virtualisation is unavailable on the nodes.
 
+   **Command** 
+   
    ```bash
    kubectl -n kubevirt patch kubevirt kubevirt --type=merge \
      --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
@@ -89,17 +107,21 @@ This feature is experimental and should be evaluated in non-production environme
 
 4. Wait for KubeVirt to become available.
 
+   **Command** 
+   
    ```bash
    kubectl -n kubevirt wait kv kubevirt --for condition=Available --timeout=5m
    ```
 
 5. Verify the installation.
 
+   **Command** 
+   
    ```bash
    kubectl get all -n kubevirt
    ```
 
-   **Sample output**
+   **Sample Output**
    ```
    NAME                                         READY   STATUS    RESTARTS      AGE
    pod/virt-api-595d49d6fd-474xq                1/1     Running   1 (25h ago)   26h
@@ -116,19 +138,21 @@ This feature is experimental and should be evaluated in non-production environme
    kubevirt.kubevirt.io/kubevirt   26h   Deployed
    ```
 
-## Install CDI
+## Install Containerized Data Importer
 
-CDI (Containerized Data Importer) manages the import and cloning of VM disk images into PersistentVolumes.
+Containerized Data Importer (CDI) manages the import and cloning of VM disk images into PersistentVolumes.
 
-1. Install the CDI Operator and Custom Resource.
+1. Install the CDI Operator and CR.
 
+   **Command** 
+   
    ```bash
    export VERSION=$(basename $(curl -s -w %{redirect_url} https://github.com/kubevirt/containerized-data-importer/releases/latest))
    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
    ```
 
-   **Sample output**
+   **Sample Output**
    ```
    namespace/cdi created
    customresourcedefinition.apiextensions.k8s.io/cdis.cdi.kubevirt.io created
@@ -165,11 +189,15 @@ CDI (Containerized Data Importer) manages the import and cloning of VM disk imag
 
    Restart containerd after the config change:
 
+   **Command**
+   
    ```bash
    sudo systemctl restart containerd
    ```
 
 3. Wait for CDI to become available.
+
+   **Command**
 
    ```bash
    kubectl -n cdi wait cdi cdi --for condition=Available --timeout=5m
@@ -177,11 +205,13 @@ CDI (Containerized Data Importer) manages the import and cloning of VM disk imag
 
 4. Verify the installation.
 
+   **Command**
+   
    ```bash
    kubectl get all -n cdi
    ```
 
-   **Sample output**
+   **Sample Output**
    ```
    NAME                                         READY   STATUS    RESTARTS        AGE
    pod/cdi-apiserver-5bbd7b4df5-28gm8           1/1     Running   1 (2m55s ago)   3m
@@ -195,6 +225,8 @@ CDI (Containerized Data Importer) manages the import and cloning of VM disk imag
 `virtctl` is the CLI companion to `kubectl` for KubeVirt operations such as accessing the VM console and triggering live migration.
 
 Download the binary that matches your installed KubeVirt version:
+
+**Command**
 
 ```bash
 VERSION=$(kubectl get kubevirt.kubevirt.io/kubevirt -n kubevirt -o=jsonpath="{.status.observedKubeVirtVersion}")
@@ -210,148 +242,165 @@ Verify:
 virtctl version
 ```
 
-### Alternative: install `virtctl` via krew
+### Alternative - Install `virtctl` via krew
 
 If you already use kubectl plugins through krew, you can install the `virt` plugin:
+
+**Command**
 
 ```bash
 kubectl krew install virt
 kubectl virt version
 ```
 
-Refer to the [official virtctl documentation](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/) for installation on other operating systems.
+Refer to the [Official virtctl Documentation](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/) for installation on other operating systems.
 
-## 1) Create a StorageClass
+## Create a StorageClass
 
-Create a StorageClass backed by Replicated PV Mayastor using the NVMe-oF protocol. Two replicas are sufficient for migration testing.
+1. Create a StorageClass backed by Replicated PV Mayastor using the NVMe-oF protocol. Two replicas are sufficient for migration testing.
 
-**storageclass-rwx-block.yaml**
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: mayastor-rwx-block
-parameters:
-  protocol: nvmf
-  repl: "2"
-  thin: "true"
-  rwxBlock: "true"
-provisioner: io.openebs.csi-mayastor
-reclaimPolicy: Delete
-volumeBindingMode: Immediate
-allowVolumeExpansion: true
-```
-
-Apply it:
-
-```bash
-kubectl apply -f storageclass-rwx-block.yaml
-```
-
-## 2) Create a block-mode DataVolume
-
-Create a DataVolume using `accessModes: ReadWriteMany` and `volumeMode: Block`. This provisions a native RWX block PVC directly via Mayastor — no NFS pod is required.
-
-**dv-rwx-block.yaml**
-```yaml
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataVolume
-metadata:
-  name: ubuntu-rwx-block
-spec:
-  storage:
-    accessModes:
-      - ReadWriteMany
-    resources:
-      requests:
-        storage: 8Gi
-    storageClassName: mayastor-rwx-block
-    volumeMode: Block
-  source:
-    http:
-      url: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
-```
-
-Apply it:
-
-```bash
-kubectl apply -f dv-rwx-block.yaml
-```
-
-Wait until the DataVolume reports `Succeeded`:
-
-```bash
-kubectl get datavolume ubuntu-rwx-block -w
-```
-
-## 3) Create a VM
-
-Create a VM manifest that:
-- references the `ubuntu-rwx-block` PVC as a block disk
-- sets `evictionStrategy: LiveMigrate`
-
-**vm-rwx-block.yaml**
-```yaml
-apiVersion: kubevirt.io/v1
-kind: VirtualMachine
-metadata:
-  name: vm-rwx
-spec:
-  runStrategy: Always
-  template:
+    **storageclass-rwx-block.yaml**
+    ```yaml
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
     metadata:
-      labels:
-        kubevirt.io/domain: vm-rwx
+      name: mayastor-rwx-block
+    parameters:
+      protocol: nvmf
+      repl: "2"
+      thin: "true"
+      rwxBlock: "true"
+    provisioner: io.openebs.csi-mayastor
+    reclaimPolicy: Delete
+    volumeBindingMode: Immediate
+    allowVolumeExpansion: true
+    ```
+
+2. Apply it:
+
+    **Command**
+
+    ```bash
+    kubectl apply -f storageclass-rwx-block.yaml
+    ```
+
+## Create a block-mode DataVolume
+
+1. Create a DataVolume using `accessModes: ReadWriteMany` and `volumeMode: Block`. This provisions a native RWX block PVC directly via Mayastor - no NFS pod is required.
+
+    **dv-rwx-block.yaml**
+    ```yaml
+    apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
+      name: ubuntu-rwx-block
     spec:
-      evictionStrategy: LiveMigrate
-      terminationGracePeriodSeconds: 30
-      networks:
-      - name: default
-        pod: {}
-      domain:
-        cpu:
-          cores: 1
-        devices:
-          interfaces:
-          - name: default
-            masquerade: {}
-          disks:
-          - disk:
-              bus: virtio
-            name: disk0
-        machine:
-          type: q35
+      storage:
+        accessModes:
+          - ReadWriteMany
         resources:
           requests:
-            memory: 1024M
-      volumes:
-      - name: disk0
-        persistentVolumeClaim:
-          claimName: ubuntu-rwx-block
-```
+            storage: 8Gi
+        storageClassName: mayastor-rwx-block
+        volumeMode: Block
+      source:
+        http:
+          url: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+    ```
 
-Apply it:
+2. Apply it:
 
-```bash
-kubectl apply -f vm-rwx-block.yaml
-```
+    **Command**
 
-Verify the VM reaches `Running` state:
+    ```bash
+    kubectl apply -f dv-rwx-block.yaml
+    ```
 
-```bash
-kubectl get vm vm-rwx
-kubectl get vmi vm-rwx -o wide
-```
+3. Wait until the DataVolume reports `Succeeded`:
 
-## 4) Trigger and validate live migration
+    **Command**
+    
+    ```bash
+    kubectl get datavolume ubuntu-rwx-block -w
+    ```
+
+## Create a VM
+
+1. Create a VM manifest that:
+    - References the `ubuntu-rwx-block` PVC as a block disk
+    - Sets `evictionStrategy: LiveMigrate`
+
+    **vm-rwx-block.yaml**
+  
+    ```yaml
+    apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      name: vm-rwx
+    spec:
+      runStrategy: Always
+      template:
+        metadata:
+          labels:
+            kubevirt.io/domain: vm-rwx
+        spec:
+          evictionStrategy: LiveMigrate
+          terminationGracePeriodSeconds: 30
+          networks:
+          - name: default
+            pod: {}
+          domain:
+            cpu:
+              cores: 1
+            devices:
+              interfaces:
+              - name: default
+                masquerade: {}
+              disks:
+              - disk:
+                  bus: virtio
+                name: disk0
+            machine:
+              type: q35
+            resources:
+              requests:
+                memory: 1024M
+          volumes:
+          - name: disk0
+            persistentVolumeClaim:
+              claimName: ubuntu-rwx-block
+    ```
+
+2. Apply it:
+
+    **Command**
+
+    ```bash
+    kubectl apply -f vm-rwx-block.yaml
+    ```
+
+3. Verify the VM reaches `Running` state:
+
+    **Command**
+
+    ```bash
+    kubectl get vm vm-rwx
+    kubectl get vmi vm-rwx -o wide
+    ```
+
+## Trigger and Validate Live Migration
 
 Trigger migration:
+
+**Command**
 
 ```bash
 virtctl migrate vm-rwx
 ```
 
 Monitor migration progress:
+
+**Command**
 
 ```bash
 kubectl get vmi vm-rwx -o yaml | grep -A4 migrationState
@@ -361,28 +410,33 @@ After migration completes, verify:
 - VM is running on a different node
 - Data is intact inside the VM
 
-## Known limitation
+## Known Limitations
 
 During migration, if a network partition causes this asymmetry:
-- **source node can still reach the NVMe-oF target**, but
-- **target node cannot reach the NVMe-oF target**,
+- **Source node can still reach the NVMe-oF target**, but
+- **Target node cannot reach the NVMe-oF target**,
 
 then the current high-availability behavior may repeatedly trigger failover/republish attempts (connection "ping-pong") until migration recovery fails.
 
 This is a known gap in the current HA logic, which currently detects path failures on a **per node-path** basis independently. A more robust fix would require the **Mayastor HA node agent** to become volume-aware for multi-attach migration scenarios, so that a republish result for one path is shared with all other connected nodes rather than triggering a chain of independent failover requests.
 
-## Feedback requested
+## Provide Feedback
 
-Please test this feature and share your results, especially around:
-- migration stability under normal conditions
-- failover and reconnection behavior
-- behavior under network faults
+As this feature is experimental, OpenEBS welcomes feedback from users evaluating its functionality and behavior in test environments.
 
-You can report your findings in:
+When sharing feedback, please focus on the following areas:
+
+- Migration stability under normal conditions
+- Failover and reconnection behavior
+- Behavior under network faults
+
+Submit your feedback through one of the following channels:
+
 - [OpenEBS issues](https://github.com/openebs/openebs/issues)
 - [OpenEBS discussions](https://github.com/openebs/openebs/discussions)
 
-Please include:
+To assist with troubleshooting and analysis, include the following information where applicable:
+
 - OpenEBS, Kubernetes, and KubeVirt versions
 - StorageClass and VM specs (sanitized)
 - Migration timeline and relevant events or logs

--- a/docs/main/Solutioning/kubevirt.md
+++ b/docs/main/Solutioning/kubevirt.md
@@ -15,9 +15,11 @@ description: Learn how to test the experimental native RWX block volume support 
 
 Replicated PV Mayastor provides experimental support for native ReadWriteMany (RWX) block volumes to enable KubeVirt Virtual Machine (VM) live migration without requiring an intermediary NFS layer.
 
-This capability allows multiple KubeVirt nodes to maintain concurrent access to the same block volume during migration, enabling VM workloads to move between nodes while preserving storage access.
+This capability is intended exclusively for KubeVirt live migration workloads, where KubeVirt performs the required migration orchestration.
 
-This document describes how to deploy, validate, and evaluate the experimental native ReadWriteMany (RWX) block volume support for KubeVirt live migration. It also provides guidance for testing the feature and submitting feedback to the OpenEBS team.
+During a migration operation, both the source and destination nodes may maintain connectivity to the volume. However, only one VM instance accesses the block volume at a given time.
+
+This document helps you test the workflow and provide feedback to the OpenEBS team.
 
 Refer [OEP: RWX Block Volume Support in Replicated PV Mayastor for KubeVirt](https://github.com/openebs/openebs/blob/develop/designs/replicated-pv/mayastor/rwx-kubevirt.md) for design/implementation details.
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/diskpool-io-failure-handling.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/diskpool-io-failure-handling.md
@@ -144,8 +144,8 @@ kubectl openebs mayastor get pool <pool-name> -n <namespace>
 **Sample Output**
 
 ```
-NAME               NODE          STATE     STATUS   ERROR   ALERTS                ENCRYPTED   CAPACITY   USED   AVAILABLE   DISK-CAPACITY   MAX-EXPANDABLE-SIZE
-pool-kind-worker   kind-worker   Created   Online           Attention (IoError)   false       508 MiB    0 B    508 MiB     512 MiB         127.8 GiB
+ID                DISKS                         MANAGED  NODE         STATUS  ALERTS               CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  ENCRYPTED  DISK-CAPACITY  MAX-EXPANDABLE-SIZE  VOLUMES  SNAPSHOTS 
+pool-kind-worker  aio:///dev/kind-worker/lvol0  true     kind-worker  Online  Attention (IoError)  508 MiB   0 B        508 MiB    0 B        false      512 MiB        127.8 GiB            0        0 
 ```
 
 ## View DiskPool Details
@@ -161,6 +161,6 @@ kubectl get dsp <pool-name> -n <namespace>
 **Sample Output**
 
 ```
-ID                DISKS                         MANAGED  NODE         STATUS  ALERTS               CAPACITY  ALLOCATED  AVAILABLE  COMMITTED  ENCRYPTED  DISK-CAPACITY  MAX-EXPANDABLE-SIZE  VOLUMES  SNAPSHOTS 
-pool-kind-worker  aio:///dev/kind-worker/lvol0  true     kind-worker  Online  Attention (IoError)  508 MiB   0 B        508 MiB    0 B        false      512 MiB        127.8 GiB            0        0 
+NAME               NODE          STATE     STATUS   ERROR   ALERTS                ENCRYPTED   CAPACITY   USED   AVAILABLE   DISK-CAPACITY   MAX-EXPANDABLE-SIZE
+pool-kind-worker   kind-worker   Created   Online           Attention (IoError)   false       508 MiB    0 B    508 MiB     512 MiB         127.8 GiB
 ```

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-create-diskpool.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-create-diskpool.md
@@ -82,8 +82,7 @@ This can be achieved in two ways:
 
     **Example DiskPool Definition with Labels**
 
-      ```
-      cat <<EOF | kubectl create -f -
+      ```yaml
       apiVersion: "openebs.io/v1beta3"
       kind: DiskPool
       metadata:
@@ -92,10 +91,10 @@ This can be achieved in two ways:
       spec:
         node: workernode-1-hostname
         disks: ["aio:///dev/disk/by-id/<id>"]
+        maxExpansion: "5x"
         topology:
           labelled:
             topology-key: topology-value
-      EOF
       ```
 
 2. The existing pools can be labelled using the plugin. This will not affect any of the pre-existing volumes.

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-create-diskpool.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-create-diskpool.md
@@ -33,7 +33,7 @@ Usage of the device name (for example, /dev/sdx) is not advised, as it may chang
 
 | Type | Format | Example |
 | :--- | :--- | :--- |
-| Disk(non PCI) with disk-by-guid reference <i><b>(Best Practice)</b></i> | Device File | aio:///dev/disk/by-id/<id> OR uring:///dev/disk/by-id/</id> |
+| Disk (non PCI) with disk-by-guid reference <i><b>(Best Practice)</b></i> | Device File | aio:///dev/disk/by-id/<id>or uring:///dev/disk/by-id/</id> |
 | Asynchronous Disk \(AIO\) | Device File | /dev/sdx |
 | Asynchronous Disk I/O \(AIO\) | Device File | aio:///dev/sdx |
 | io\_uring | Device File | uring:///dev/sdx |

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-create-diskpool.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-create-diskpool.md
@@ -15,7 +15,7 @@ When a node allocates storage capacity for a replica of a Persistent Volume (PV)
 
 A pool is defined declaratively, through the creation of a corresponding `DiskPool` Custom Resource (CR) on the cluster. The DiskPool must be created in the same namespace where the Replicated PV Mayastor has been deployed. User configurable parameters of this resource type include a unique name for the pool, the node name on which it will be hosted and a reference to a disk device that is accessible from that node. The pool definition requires the reference to its member block device to adhere to a discrete range of schemas, each associated with a specific access mechanism/transport/ or device type.
 
-**Permissible Schemes for `spec.disks` under DiskPool Custom Resource**
+**Permissible Schemes for `spec.disks` under DiskPool CR**
 
 :::info
 It is highly recommended to specify the disk using a unique device link that remains unaltered across node reboots. Examples of such device links are: by-path or by-id.
@@ -34,7 +34,7 @@ Usage of the device name (for example, /dev/sdx) is not advised, as it may chang
 | Type | Format | Example |
 | :--- | :--- | :--- |
 | Disk(non PCI) with disk-by-guid reference <i><b>(Best Practice)</b></i> | Device File | aio:///dev/disk/by-id/<id> OR uring:///dev/disk/by-id/</id> |
-| Asynchronous Disk\(AIO\) | Device File | /dev/sdx |
+| Asynchronous Disk \(AIO\) | Device File | /dev/sdx |
 | Asynchronous Disk I/O \(AIO\) | Device File | aio:///dev/sdx |
 | io\_uring | Device File | uring:///dev/sdx |
 
@@ -135,11 +135,12 @@ kubectl get dsp -n openebs
 ```
 
 **Example Output**
-```text
-NAME             NODE          STATE     POOL_STATUS   CAPACITY      USED   AVAILABLE
-pool-on-node-1   node-1-14944  Created   Online        10724835328   0      10724835328
-pool-on-node-2   node-2-14944  Created   Online        10724835328   0      10724835328
-pool-on-node-3   node-3-14944  Created   Online        10724835328   0      10724835328
+```
+NAME                      NODE            STATE     STATUS   ERROR   ALERTS    ENCRYPTED   CAPACITY   USED   AVAILABLE   DISK-CAPACITY   MAX-EXPANDABLE-SIZE
+pool-1-on-node-0-474840   node-0-474840   Created   Online           Healthy   false       10 GiB     0 B    10 GiB      10 GiB          127.8 GiB
+pool-1-on-node-1-474840   node-1-474840   Created   Online           Healthy   false       10 GiB     0 B    10 GiB      10 GiB          127.8 GiB
+pool-1-on-node-2-474840   node-2-474840   Created   Online           Healthy   false       10 GiB     0 B    10 GiB      10 GiB          127.8 GiB
+ 
 ```
 
 ## See Also

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-create-diskpool.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-create-diskpool.md
@@ -49,11 +49,19 @@ A RAM drive is not suitable for use in production as it uses volatile memory for
 
 To get started, it is necessary to create and host at least one pool on one of the nodes in the cluster. The number of pools available limits the extent to which the synchronous N-way mirroring (replication) of PVs can be configured; the number of pools configured should be equal to or greater than the desired maximum replication factor of the PVs to be created. Also, while placing data replicas ensure that appropriate redundancy is provided. Replicated PV Mayastor's control plane will avoid placing more than one replica of a volume on the same node. For example, the minimum viable configuration for a Replicated PV Mayastor deployment which is intended to implement 3-way mirrored PVs must have three nodes, each having one DiskPool, with each of those pools having one unique block device allocated to it.
 
-Create the required type and number of pools by using one or more of the following examples as templates. 
+Create the required type and number of pools by using one or more of the following examples as templates.
+
+:::important
+
+When creating a DiskPool, consider configuring the `maxExpansion` parameter. This parameter defines the maximum size to which a DiskPool can be expanded in the future and cannot be modified after the DiskPool is created.
+
+If `maxExpansion` is not specified, the default value is 1x, which means the pool cannot grow beyond its initial size.
+
+Refer [DiskPool Expansion](../advanced-operations/diskpool-expansion.md) for information about supported values, sizing considerations, and expansion procedures.
+:::
 
 **Example DiskPool Definition**
-```text
-cat <<EOF | kubectl create -f -
+```yaml
 apiVersion: "openebs.io/v1beta3"
 kind: DiskPool
 metadata:
@@ -62,55 +70,60 @@ metadata:
 spec:
   node: workernode-1-hostname
   disks: ["aio:///dev/disk/by-id/<id>"]
-EOF
+  maxExpansion: "5x"
 ```
+
+`maxExpansion` - Optional. Defines the maximum size to which the DiskPool can grow. Supports factor-based values (for example, `5x`) or absolute sizes (for example, `6TiB`). This value cannot be changed after pool creation.
 
 Inorder to place the volume replicas based on the pool labels i.e. to satisfy `poolHasTopologyKey` and `poolAffinityTopologyLabel` parameters of the storage class, the pools must be labelled with the topology field.
 This can be achieved in two ways:
 
 1. Create a new pool with the labels.
 
-**Example DiskPool Definition with Labels**
-```
-cat <<EOF | kubectl create -f -
-apiVersion: "openebs.io/v1beta3"
-kind: DiskPool
-metadata:
-  name: pool-on-node-1
-  namespace: openebs
-spec:
-  node: workernode-1-hostname
-  disks: ["aio:///dev/disk/by-id/<id>"]
-  topology:
-    labelled:
-      topology-key: topology-value
-EOF
-```
+    **Example DiskPool Definition with Labels**
+
+      ```
+      cat <<EOF | kubectl create -f -
+      apiVersion: "openebs.io/v1beta3"
+      kind: DiskPool
+      metadata:
+        name: pool-on-node-1
+        namespace: openebs
+      spec:
+        node: workernode-1-hostname
+        disks: ["aio:///dev/disk/by-id/<id>"]
+        topology:
+          labelled:
+            topology-key: topology-value
+      EOF
+      ```
 
 2. The existing pools can be labelled using the plugin. This will not affect any of the pre-existing volumes.
 
-```
-kubectl mayastor label pool pool-on-node-1 topology-key=topology-value -n openebs
-```
+    ```
+    kubectl mayastor label pool pool-on-node-1 topology-key=topology-value -n openebs
+    ```
 
-**YAML**
-```text
-apiVersion: "openebs.io/v1beta3"
-kind: DiskPool
-metadata:
-  name: INSERT_POOL_NAME_HERE
-  namespace: openebs
-spec:
-  node: INSERT_WORKERNODE_HOSTNAME_HERE
-  disks: ["INSERT_DEVICE_URI_HERE"]
-```
-
-:::info
-When using the examples given as guides to creating your own pools, remember to replace the values for the fields "metadata.name", "spec.node" and "spec.disks" as appropriate to your cluster's intended configuration. Note that whilst the "disks" parameter accepts an array of values, the current version of Replicated PV Mayastor supports only one disk device per pool.
-:::
+    **YAML**
+    ```yaml
+    apiVersion: "openebs.io/v1beta3"
+    kind: DiskPool
+    metadata:
+      name: INSERT_POOL_NAME_HERE
+      namespace: openebs
+    spec:
+      node: INSERT_WORKERNODE_HOSTNAME_HERE
+      disks: ["INSERT_DEVICE_URI_HERE"]
+      maxExpansion: ["INSERT_MAX_EXPANSION_VALUE"]
+    ```
 
 :::note
-After upgrading to Replicated PV Mayastor 2.4 and above, existing schemas in CR definitions from earlier versions (including `v1alpha1`, `v1beta1`, etc.) will be updated to `v1beta3`. If you encounter errors during the upgrade, refer to the [Troubleshooting - Replicated Storage documentation](../../../../troubleshooting/troubleshooting-replicated-storage.md) for resolution steps.
+
+- When using the examples given as guides to creating your own pools, remember to replace the values for the fields "metadata.name", "spec.node" and "spec.disks" as appropriate to your cluster's intended configuration. Note that whilst the "disks" parameter accepts an array of values, the current version of Replicated PV Mayastor supports only one disk device per pool.
+
+- Consider configuring `spec.maxExpansion` during pool creation. This field determines the maximum future expansion limit of the DiskPool and cannot be modified after the pool has been created.
+
+- After upgrading to Replicated PV Mayastor 2.4 and above, existing schemas in CR definitions from earlier versions (including `v1alpha1`, `v1beta1`, etc.) will be updated to `v1beta3`. If you encounter errors during the upgrade, refer to the [Troubleshooting - Replicated Storage documentation](../../../../troubleshooting/troubleshooting-replicated-storage.md) for resolution steps.
 :::
 
 ## Verify Pool Creation and Status
@@ -124,7 +137,7 @@ kubectl get dsp -n openebs
 
 **Example Output**
 ```text
-NAME             NODE          STATE    POOL_STATUS   CAPACITY      USED   AVAILABLE
+NAME             NODE          STATE     POOL_STATUS   CAPACITY      USED   AVAILABLE
 pool-on-node-1   node-1-14944  Created   Online        10724835328   0      10724835328
 pool-on-node-2   node-2-14944  Created   Online        10724835328   0      10724835328
 pool-on-node-3   node-3-14944  Created   Online        10724835328   0      10724835328


### PR DESCRIPTION
- Update the KubeVirt VM Live Migration with Experimental RWX Block Volumes documentation to align with OpenEBS documentation standards.
- Update the Create DiskPool documentation to add `maxExpansion` details.
