### PR TITLE
docs: add complete Local PV Rawfile documentation

### DIFF
--- a/docs/main/quickstart-guide/deploy-a-test-application.md
+++ b/docs/main/quickstart-guide/deploy-a-test-application.md
@@ -17,6 +17,7 @@ This document demonstrates how to deploy an application using OpenEBS Local PV H
 If you want to use other OpenEBS storages, refer to the following documentation:
 - [Local PV LVM Deployment](../user-guides/local-storage-user-guide/local-pv-lvm/configuration/lvm-deployment.md)
 - [Local PV ZFS Deployment](../user-guides/local-storage-user-guide/local-pv-zfs/configuration/zfs-deployment.md)
+- [Local PV Rawfile Deployment](../user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment.md)
 - [Replicated PV Mayastor Deployment](../user-guides/replicated-storage-user-guide/replicated-pv-mayastor/configuration/rs-deployment.md)
 :::
 

--- a/docs/main/quickstart-guide/installation.md
+++ b/docs/main/quickstart-guide/installation.md
@@ -52,13 +52,19 @@ Verify helm is installed and helm repo is updated. You need helm 3.2 or more.
     helm install openebs --namespace openebs openebs/openebs --create-namespace
     ```
 
-    The above command will install OpenEBS Local PV Hostpath, OpenEBS Local PV LVM, OpenEBS Local PV ZFS, and OpenEBS Replicated Storage components in `openebs` namespace and chart name as `openebs`.
+    The above command will install OpenEBS Local PV Hostpath, OpenEBS Local PV LVM, OpenEBS Local PV ZFS, and OpenEBS Replicated Storage components in `openebs` namespace and chart name as `openebs`. OpenEBS Local PV Rawfile is not installed by default.
 
     :::important
     - The default OpenEBS helm chart will install both Local Storage and Replicated Storage. If you do not want to install OpenEBS Replicated Storage, use the following command:
 
       ```
       helm install openebs --namespace openebs openebs/openebs --set engines.replicated.mayastor.enabled=false --create-namespace
+      ```
+
+    - OpenEBS Local PV Rawfile is disabled by default. To enable it during installation, use the following command:
+
+      ```
+      helm install openebs --namespace openebs openebs/openebs --set engines.local.rawfile.enabled=true --create-namespace
       ```
 
     - If the CustomResourceDefinitions for CSI VolumeSnapshots are already present in your cluster, you may skip their creation by using the following option:

--- a/docs/main/quickstart-guide/prerequisites.md
+++ b/docs/main/quickstart-guide/prerequisites.md
@@ -11,6 +11,7 @@ If you are installing OpenEBS, make sure that your Kubernetes nodes meet the req
 - [Local PV Hostpath Prerequisites](#local-pv-hostpath-prerequisites)
 - [Local PV LVM Prerequisites](#local-pv-lvm-prerequisites)
 - [Local PV ZFS Prerequisites](#local-pv-zfs-prerequisites)
+- [Local PV Rawfile Prerequisites](#local-pv-rawfile-prerequisites)
 - [Replicated PV Mayastor Prerequisites](#replicated-pv-mayastor-prerequisites).
 
 At a high-level, OpenEBS requires:
@@ -116,6 +117,32 @@ errors: No known data errors
 ```
 
 Configure the [custom topology keys](../faqs/faqs.md#how-to-add-custom-topology-key-to-local-pv-zfs-driver) (if needed). This can be used for many purposes like if we want to create the PV on nodes in a particular zone or building. We can label the nodes accordingly and use that key in the storageclass for making the scheduling decision.
+
+## Local PV Rawfile Prerequisites
+
+:::note
+Local PV Rawfile is disabled by default in the OpenEBS Helm chart. These prerequisites apply only if you intend to enable and use it.
+:::
+
+Before enabling the Rawfile driver, make sure each Kubernetes node meets the following requirements:
+
+1. Linux nodes with loop device support - verify that `losetup` is available on each node.
+2. Filesystem tools must be installed on each node for the filesystem type you intend to use:
+   - **ext4** (default): `e2fsprogs` (`mkfs.ext4`)
+   - **xfs**: `xfsprogs` (`mkfs.xfs`)
+   - **btrfs**: `btrfs-progs` (`mkfs.btrfs`)
+
+   To install on Ubuntu/Debian:
+   ```
+   apt-get install e2fsprogs xfsprogs btrfs-progs
+   ```
+
+   To install on RHEL/CentOS:
+   ```
+   yum install e2fsprogs xfsprogs btrfs-progs
+   ```
+
+3. The storage pool directory (default: `/var/csi/rawfile`) must exist or be creatable on each node, with sufficient disk space for the volumes you plan to provision.
 
 ## Replicated PV Mayastor Prerequisites
 

--- a/docs/main/quickstart-guide/prerequisites.md
+++ b/docs/main/quickstart-guide/prerequisites.md
@@ -124,25 +124,11 @@ Configure the [custom topology keys](../faqs/faqs.md#how-to-add-custom-topology-
 Local PV Rawfile is disabled by default in the OpenEBS Helm chart. These prerequisites apply only if you intend to enable and use it.
 :::
 
-Before enabling the Rawfile driver, make sure each Kubernetes node meets the following requirements:
+The Rawfile driver container image bundles all required tools (`losetup`, `mkfs.ext4`, `mkfs.xfs`, `mkfs.btrfs`) — no host-level installation of these tools is needed.
 
-1. Linux nodes with loop device support - verify that `losetup` is available on each node.
-2. Filesystem tools must be installed on each node for the filesystem type you intend to use:
-   - **ext4** (default): `e2fsprogs` (`mkfs.ext4`)
-   - **xfs**: `xfsprogs` (`mkfs.xfs`)
-   - **btrfs**: `btrfs-progs` (`mkfs.btrfs`)
+The only host-side requirement is:
 
-   To install on Ubuntu/Debian:
-   ```
-   apt-get install e2fsprogs xfsprogs btrfs-progs
-   ```
-
-   To install on RHEL/CentOS:
-   ```
-   yum install e2fsprogs xfsprogs btrfs-progs
-   ```
-
-3. The storage pool directory (default: `/var/csi/rawfile`) must exist or be creatable on each node, with sufficient disk space for the volumes you plan to provision.
+- The storage pool directory (default: `/var/csi/rawfile`) must exist or be creatable on each node, with sufficient disk space for the volumes you plan to provision.
 
 ## Replicated PV Mayastor Prerequisites
 

--- a/docs/main/quickstart-guide/prerequisites.md
+++ b/docs/main/quickstart-guide/prerequisites.md
@@ -130,6 +130,10 @@ The only host-side requirement is:
 
 - The storage pool directory (default: `/var/csi/rawfile`) must exist or be creatable on each node, with sufficient disk space for the volumes you plan to provision.
 
+:::note
+**Copy-on-Write (CoW) snapshots and clones:** If you want space-efficient, near-instant snapshots and clones, the underlying filesystem of the storage pool directory must support reflinks. btrfs supports this natively. XFS supports it when formatted with `mkfs.xfs -m reflink=1`. ext4 does not currently support reflinks. Without CoW, snapshots and clones perform a full data copy instead.
+:::
+
 ## Replicated PV Mayastor Prerequisites
 
 ### General

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring.md
@@ -1,4 +1,4 @@
----
+﻿---
 id: rawfile-monitoring
 title: Monitoring
 keywords:
@@ -127,7 +127,7 @@ Metrics were renamed in **v0.14.1**. If you are upgrading from an earlier versio
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring.md
@@ -1,0 +1,136 @@
+---
+id: rawfile-monitoring
+title: Monitoring
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Monitoring
+ - Prometheus
+ - Metrics
+description: This document describes the Prometheus metrics exposed by Local PV Rawfile and how to configure scraping.
+---
+
+Local PV Rawfile exposes Prometheus metrics from the node plugin on each node. Metrics are organized at three levels: node, pool, and volume.
+
+## Enable Metrics
+
+Metrics are enabled by default. To disable them:
+
+```yaml
+metrics:
+  enabled: false
+```
+
+Metrics are exposed on port **9100** (configurable).
+
+## Configure Prometheus Scraping
+
+### Prometheus Operator (ServiceMonitor)
+
+Enable the ServiceMonitor for automatic scraping:
+
+```yaml
+metrics:
+  serviceMonitor:
+    enabled: true
+    interval: 1m
+```
+
+Apply:
+
+```bash
+helm upgrade rawfile-localpv rawfile-localpv/rawfile-localpv -n openebs \
+  --set metrics.serviceMonitor.enabled=true
+```
+
+### Manual Scraping
+
+Add a scrape job to your Prometheus configuration:
+
+```yaml
+scrape_configs:
+  - job_name: rawfile-localpv
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: [openebs]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        regex: rawfile-localpv-node
+        action: keep
+      - source_labels: [__address__]
+        target_label: __address__
+        replacement: $1:9100
+```
+
+## Metrics Reference
+
+### Node-Level Metrics
+
+| Metric | Labels | Description |
+|---|---|---|
+| `rawfile_remaining_capacity_bytes` | `node` | Free capacity for new volumes on this node, excluding reserved storage |
+
+### Pool-Level Metrics
+
+| Metric | Labels | Description |
+|---|---|---|
+| `rawfile_pool_capacity_bytes` | `node`, `pool` | Maximum usable capacity of the pool |
+| `rawfile_pool_remaining_capacity_bytes` | `node`, `pool` | Remaining free capacity in the pool |
+| `rawfile_pool_reserved_capacity_bytes` | `node`, `pool` | Capacity reserved for non-pool use |
+| `rawfile_pool_backing_fs_capacity_bytes` | `node`, `pool` | Total capacity of the backing filesystem |
+| `rawfile_pool_backing_fs_available_bytes` | `node`, `pool` | Available bytes on the backing filesystem |
+| `rawfile_pool_backing_fs_usage_bytes` | `node`, `pool` | Used bytes on the backing filesystem |
+| `rawfile_pool_volumes_physical_bytes` | `node`, `pool` | Physical disk bytes consumed by all volumes in the pool |
+| `rawfile_pool_volumes_logical_bytes` | `node`, `pool` | Logical (provisioned) bytes of all volumes in the pool |
+| `rawfile_pool_volume_count` | `node`, `pool` | Number of volumes in the pool |
+| `rawfile_pool_info` | `node`, `pool`, `path`, `fs_type` | Pool metadata (labels only, value always 1) |
+
+### Volume-Level Metrics
+
+| Metric | Labels | Description |
+|---|---|---|
+| `rawfile_volume_used_bytes` | `node`, `pool`, `volume` | Bytes currently used inside the volume |
+| `rawfile_volume_total_bytes` | `node`, `pool`, `volume` | Total provisioned size of the volume |
+| `rawfile_volume_physical_bytes` | `node`, `pool`, `volume` | Physical disk bytes consumed by the volume (may differ from logical for thin or CoW volumes) |
+| `rawfile_volume_info` | `node`, `pool`, `volume`, `pvc`, `namespace` | Volume metadata (labels only, value always 1) |
+
+## Example PromQL Queries
+
+**Alert when a volume is more than 90% full:**
+
+```promql
+rawfile_volume_used_bytes / rawfile_volume_total_bytes > 0.9
+```
+
+**Alert when a pool has less than 10 GiB free:**
+
+```promql
+rawfile_pool_remaining_capacity_bytes < 10 * 1024^3
+```
+
+**Thin-provisioning overcommit ratio per pool:**
+
+```promql
+rawfile_pool_volumes_logical_bytes / rawfile_pool_capacity_bytes
+```
+
+**Physical vs. logical usage per pool (CoW space savings):**
+
+```promql
+1 - (rawfile_pool_volumes_physical_bytes / rawfile_pool_volumes_logical_bytes)
+```
+:::note
+Metrics were renamed in **v0.14.1**. If you are upgrading from an earlier version, update any dashboards or alert rules that reference the old metric names.
+:::
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Storage Pools](rawfile-storage-pools.md)
+- [Volume Resize](rawfile-resize.md)
+- [Thin Provisioning](rawfile-thin-provisioning.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring.md
@@ -85,16 +85,16 @@ scrape_configs:
 | `rawfile_pool_volumes_physical_bytes` | `node`, `pool` | Physical disk bytes consumed by all volumes in the pool |
 | `rawfile_pool_volumes_logical_bytes` | `node`, `pool` | Logical (provisioned) bytes of all volumes in the pool |
 | `rawfile_pool_volume_count` | `node`, `pool` | Number of volumes in the pool |
-| `rawfile_pool_info` | `node`, `pool`, `path`, `fs_type` | Pool metadata (labels only, value always 1) |
+| `rawfile_pool_info` | `node`, `pool`, `mode`, `default_pool` | Pool metadata (labels only, value always 1) |
 
 ### Volume-Level Metrics
 
 | Metric | Labels | Description |
 |---|---|---|
-| `rawfile_volume_used_bytes` | `node`, `pool`, `volume` | Bytes currently used inside the volume |
-| `rawfile_volume_total_bytes` | `node`, `pool`, `volume` | Total provisioned size of the volume |
-| `rawfile_volume_physical_bytes` | `node`, `pool`, `volume` | Physical disk bytes consumed by the volume (may differ from logical for thin or CoW volumes) |
-| `rawfile_volume_info` | `node`, `pool`, `volume`, `pvc`, `namespace` | Volume metadata (labels only, value always 1) |
+| `rawfile_volume_used_bytes` | `node`, `volume` | Bytes currently used inside the volume |
+| `rawfile_volume_total_bytes` | `node`, `volume` | Total provisioned size of the volume |
+| `rawfile_volume_physical_bytes` | `node`, `volume` | Physical disk bytes consumed by the volume (may differ from logical for thin or CoW volumes) |
+| `rawfile_volume_info` | `node`, `volume`, `pool`, `sparse`, `thin_provision` | Volume metadata (labels only, value always 1) |
 
 ## Example PromQL Queries
 
@@ -121,9 +121,6 @@ rawfile_pool_volumes_logical_bytes / rawfile_pool_capacity_bytes
 ```promql
 1 - (rawfile_pool_volumes_physical_bytes / rawfile_pool_volumes_logical_bytes)
 ```
-:::note
-Metrics were renamed in **v0.14.1**. If you are upgrading from an earlier version, update any dashboards or alert rules that reference the old metric names.
-:::
 
 ## Support
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-raw-block-volume.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-raw-block-volume.md
@@ -1,4 +1,4 @@
----
+﻿---
 id: rawfile-raw-block-volume
 title: Raw Block Volumes
 keywords:
@@ -106,7 +106,7 @@ Block mode volumes support online expansion. If the volume is currently unstaged
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-raw-block-volume.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-raw-block-volume.md
@@ -1,0 +1,115 @@
+---
+id: rawfile-raw-block-volume
+title: Raw Block Volumes
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Raw Block Volume
+ - Block Mode
+description: This document explains how to use Local PV Rawfile volumes in raw block mode for workloads that manage their own storage format.
+---
+
+Local PV Rawfile supports raw block volumes that expose a loop device directly to the pod without any filesystem layer. This is useful for databases and other workloads that manage their own storage format.
+
+## Create a Block Mode PVC
+
+Set `volumeMode: Block` in the PVC spec:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rawfile-block-pvc
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+```bash
+kubectl apply -f block-pvc.yaml
+```
+
+The PVC will remain in `Pending` state until a consuming pod is scheduled (`WaitForFirstConsumer`).
+
+## Consume the Block Volume in a Pod
+
+Use `volumeDevices` (not `volumeMounts`) to map the raw device into the pod:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-block
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep infinity"]
+      volumeDevices:
+        - name: data
+          devicePath: /dev/xvda
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rawfile-block-pvc
+```
+
+```bash
+kubectl apply -f pod-block.yaml
+kubectl get pvc rawfile-block-pvc
+```
+
+Once the pod is scheduled, the loop device is attached and exposed at `/dev/xvda` inside the container. The application is responsible for initializing and managing the device.
+
+## Verify the Block Device
+
+```bash
+kubectl exec app-block -- ls -l /dev/xvda
+# brw-rw---- 1 root disk 7, 3 ... /dev/xvda
+
+kubectl exec app-block -- blockdev --getsize64 /dev/xvda
+# 10737418240
+```
+
+## StorageClass Parameters for Block Mode
+
+The following StorageClass parameters are **ignored** for block mode PVCs:
+
+- `csi.storage.k8s.io/fstype` - no filesystem is created
+- `formatOptions` - no format step
+- `mountOptions` - no mount step
+- `copyOnWrite` / `freezeFs` - CoW and freeze apply to filesystem operations only
+
+All other parameters (`storagePool`, `thinProvision`, `allowVolumeExpansion`) continue to apply.
+
+:::note
+The `readOnly` attribute on block mode PVCs is not currently honored.
+:::
+
+## Volume Expansion
+
+Block mode volumes support online expansion. If the volume is currently unstaged (no pod using it), only the backing file is grown; node-side expansion is deferred until the volume is next attached. The application inside the pod is responsible for recognizing the larger device (e.g. re-reading partition tables, resizing the filesystem it manages).
+
+## Use Cases
+
+| Use Case | Why Block Mode |
+|---|---|
+| Databases (PostgreSQL, MySQL) | Direct I/O without filesystem overhead |
+| VM disk images | Raw block device maps naturally to a virtual disk |
+| Custom storage formats | Application manages its own layout on the device |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Create PVC](../configuration/rawfile-create-pvc.md)
+- [StorageClass Parameters](../configuration/rawfile-storageclass-parameters.md)
+- [Volume Resize](rawfile-resize.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-resize.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-resize.md
@@ -115,7 +115,7 @@ Block volumes (`volumeMode: Block`) are also expandable. If the volume is curren
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-resize.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-resize.md
@@ -1,0 +1,124 @@
+---
+id: rawfile-resize
+title: Volume Resize
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Volume Resize
+ - Volume Expansion
+description: This document explains how to expand Local PV Rawfile volumes online without restarting the pod.
+---
+
+Local PV Rawfile supports **online volume expansion** - the backing file, loop device, and filesystem are grown live with no pod restart required. Shrinking is not supported.
+
+## Requirements
+
+- Resize must be enabled in the chart (default): `capabilities.resize.enabled=true`
+- The StorageClass must set `allowVolumeExpansion: true`
+- Online filesystem growth is supported for `ext4`, `xfs`, and `btrfs`
+- Sufficient free capacity must exist in the volume's storage pool on its node
+
+## StorageClass Configuration
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-localpv
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+```
+
+## Expand a Volume
+
+Edit the PVC's `spec.resources.requests.storage` to the new (larger) size:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi    # was 10Gi
+```
+
+```bash
+kubectl apply -f pvc.yaml
+```
+
+Or patch in place:
+
+```bash
+kubectl patch pvc app-data \
+  -p '{"spec":{"resources":{"requests":{"storage":"20Gi"}}}}'
+```
+
+## Monitor the Expansion
+
+Watch for the capacity to update:
+
+```bash
+kubectl get pvc app-data -w
+# NAME       STATUS   VOLUME      CAPACITY   ACCESS MODES   STORAGECLASS
+# app-data   Bound    pvc-xxxxx   10Gi       RWO            rawfile-localpv
+# app-data   Bound    pvc-xxxxx   20Gi       RWO            rawfile-localpv
+```
+
+Check events and conditions if it takes longer than expected:
+
+```bash
+kubectl describe pvc app-data
+```
+
+Under the hood, the `csi-resizer` sidecar calls the controller, which forwards the request to the node that owns the volume. The node grows the backing file, resizes the loop device, and expands the filesystem online.
+
+## Verify Inside the Pod
+
+```bash
+kubectl exec app -- df -hT /data
+# Filesystem     Type  Size  Used Avail Use% Mounted on
+# /dev/loop3     ext4   20G  1.1G   18G   6% /data
+```
+
+No pod restart is needed - the new capacity is visible immediately after the resize completes.
+
+## Block Mode Volumes
+
+Block volumes (`volumeMode: Block`) are also expandable. If the volume is currently unstaged (no pod consuming it), only the backing file is grown; node-side expansion is deferred until the volume is next attached. The application inside the pod is responsible for recognizing the larger device.
+
+## Limitations
+
+| Item | Status |
+|---|---|
+| Online expansion (ext4/xfs/btrfs) while pod is running | Supported |
+| Shrinking | Not supported - requests to reduce size are rejected by Kubernetes |
+| Expansion beyond pool free space | Fails with `Not enough disk space` |
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| PVC capacity never updates | Check: `allowVolumeExpansion: true` on StorageClass, `capabilities.resize.enabled=true` in chart, controller deployment is running: `kubectl -n openebs logs deploy/<release>-controller`. |
+| `Not enough disk space` | The pool on the volume's node lacks free capacity. Free space or grow the underlying disk. Monitor: `rawfile_pool_remaining_capacity_bytes`. |
+| `Resizing capabilities are disabled` | Set `capabilities.resize.enabled=true` and upgrade the Helm release. |
+| Filesystem size unchanged but PV shows new size | Node-side expansion pending - ensure the node plugin is healthy; kubelet triggers `NodeExpandVolume` on the mounted node. |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [StorageClass Parameters](../configuration/rawfile-storageclass-parameters.md)
+- [Monitoring](rawfile-monitoring.md)
+- [Storage Pools](rawfile-storage-pools.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-snapshot.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-snapshot.md
@@ -1,0 +1,168 @@
+---
+id: rawfile-snapshot
+title: Snapshots
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Snapshots
+ - VolumeSnapshot
+description: This document explains how to create, use, and delete volume snapshots with Local PV Rawfile.
+---
+
+Local PV Rawfile supports block-level volume snapshots using the standard Kubernetes `VolumeSnapshot` API. Snapshots are node-local and processed as persistent background tasks with automatic retry across driver restarts.
+
+## Requirements
+
+- Snapshots must be enabled in the chart (default): `capabilities.snapshots.enabled=true`
+- Kubernetes VolumeSnapshot CRDs must be installed in the cluster
+- A `VolumeSnapshotClass` must exist for the rawfile driver
+
+## Create a VolumeSnapshotClass
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: rawfile-snapshotclass
+driver: rawfile.csi.openebs.io
+deletionPolicy: Delete
+```
+
+Apply:
+
+```bash
+kubectl apply -f snapshotclass.yaml
+```
+
+`deletionPolicy: Delete` removes snapshot data when the `VolumeSnapshot` object is deleted. Use `Retain` to preserve the data after object deletion.
+
+## Create a Snapshot
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: app-data-snap
+spec:
+  volumeSnapshotClassName: rawfile-snapshotclass
+  source:
+    persistentVolumeClaimName: rawfile-pvc
+```
+
+```bash
+kubectl apply -f snapshot.yaml
+kubectl get volumesnapshot app-data-snap -w
+```
+
+The snapshot is `ReadyToUse: true` when complete. The snapshot operation runs as a persistent background task on the node that hosts the volume - it survives driver restarts and retries automatically.
+
+## Snapshot Consistency
+
+Two approaches are available for snapshotting active volumes:
+
+### CoW-Capable Pools (Recommended)
+
+Storage pools backed by btrfs or XFS with reflink produce space-efficient, nearly instant snapshots. No freeze is required.
+
+### freezeFs
+
+For pools without CoW support (e.g. ext4), add `freezeFs: "true"` to the StorageClass. The filesystem is briefly frozen during the snapshot to ensure crash consistency:
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  freezeFs: "true"
+```
+
+:::warning
+With `freezeFs: "true"` on a non-CoW pool, the volume's filesystem stays frozen for the entire snapshot duration. All writes to the volume block until the snapshot completes. For large volumes this can take significant time. Prefer a CoW-capable pool filesystem where possible.
+:::
+
+## Restore a Snapshot to a New PVC
+
+Specify the snapshot as a `dataSource` in a new PVC:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data-restored
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  dataSource:
+    name: app-data-snap
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+```bash
+kubectl apply -f restore.yaml
+```
+
+:::note
+Snapshots are node-local. The restored PVC will be provisioned on the same node that holds the snapshot data.
+:::
+
+## Roll Back an Application
+
+A common pattern for rolling back to a previous state:
+
+1. Scale down the workload to release the PVC:
+   ```bash
+   kubectl scale deployment my-app --replicas=0
+   ```
+
+2. Create a restored PVC from the snapshot (see above).
+
+3. Update the Deployment to reference the restored PVC:
+   ```bash
+   kubectl patch deployment my-app \
+     -p '{"spec":{"template":{"spec":{"volumes":[{"name":"data","persistentVolumeClaim":{"claimName":"app-data-restored"}}]}}}}'
+   ```
+
+4. Scale the workload back up:
+   ```bash
+   kubectl scale deployment my-app --replicas=1
+   ```
+
+## Delete a Snapshot
+
+```bash
+kubectl delete volumesnapshot app-data-snap
+```
+
+With `deletionPolicy: Delete`, the snapshot data on the node is removed. With `Retain`, the backing data remains.
+
+:::important
+Delete all VolumeSnapshots before deleting the PVC or uninstalling the driver to avoid leaked data on nodes.
+:::
+
+## Capacity Considerations
+
+- CoW-capable pools (btrfs, XFS reflink): snapshots consume only the changed blocks after the snapshot point.
+- Non-CoW pools (ext4): each snapshot is a full copy of the volume and consumes the same amount of space as the original.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Snapshot stuck in `Pending` | Check the node plugin logs: `kubectl -n openebs logs ds/<release>-node -c csi-driver`. Snapshot operations are retried on restart. |
+| `Snapshotting capabilities are disabled` | Set `capabilities.snapshots.enabled=true` and upgrade the Helm release. |
+| No VolumeSnapshotClass found | Create a `VolumeSnapshotClass` with `driver: rawfile.csi.openebs.io`. |
+| `Insufficient disk space` | Non-CoW snapshot requires a full copy - check pool free capacity: `rawfile_pool_remaining_capacity_bytes`. |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Create StorageClass(s)](../configuration/rawfile-create-storageclass.md)
+- [Volume Restore (Cloning)](rawfile-volume-restore.md)
+- [Storage Pools](rawfile-storage-pools.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-snapshot.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-snapshot.md
@@ -63,11 +63,11 @@ Two approaches are available for snapshotting active volumes:
 
 ### CoW-Capable Pools (Recommended)
 
-Storage pools backed by btrfs or XFS with reflink produce space-efficient, nearly instant snapshots. No freeze is required.
+Storage pools backed by filesystems which support reflink (i.e. btrfs or XFS) produce space-efficient, nearly instant snapshots. No freeze is required.
 
 ### freezeFs
 
-For pools without CoW support (e.g. ext4), add `freezeFs: "true"` to the StorageClass. The filesystem is briefly frozen during the snapshot to ensure crash consistency:
+For pools without CoW support, add `freezeFs: "true"` to the StorageClass. The filesystem is frozen and the entire volume is copied to a new file before it is unfrozen:
 
 ```yaml
 parameters:
@@ -145,8 +145,8 @@ Delete all VolumeSnapshots before deleting the PVC or uninstalling the driver to
 
 ## Capacity Considerations
 
-- CoW-capable pools (btrfs, XFS reflink): snapshots consume only the changed blocks after the snapshot point.
-- Non-CoW pools (ext4): each snapshot is a full copy of the volume and consumes the same amount of space as the original.
+- CoW-capable pools (filesystems with reflink enabled): snapshots consume only the changed blocks after the snapshot point.
+- Non-CoW pools: each snapshot is a full copy of the volume and consumes the same amount of space as the original.
 
 ## Troubleshooting
 
@@ -159,7 +159,7 @@ Delete all VolumeSnapshots before deleting the PVC or uninstalling the driver to
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools.md
@@ -1,0 +1,141 @@
+---
+id: rawfile-storage-pools
+title: Storage Pools
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Storage Pools
+description: This document explains how to configure and use storage pools with Local PV Rawfile to enable storage tiering across multiple named storage locations per node.
+---
+
+Storage pools let each node offer one or more named storage locations (for example, an NVMe pool and an HDD pool), each backed by its own filesystem with independent capacity reservations. This enables storage tiering - workloads select a tier by referencing the pool name in the StorageClass.
+
+## Configure Storage Pools
+
+Pools are defined in the Helm chart values under `node.storagePools`. A `node.defaultPool` is required and must reference one of the defined pools.
+
+```yaml
+node:
+  defaultPool: hdd
+  storagePools:
+    hdd:
+      path: /var/local/openebs/rawfile/hdd/
+      reservedCapacity: "10%"
+      reservedCapacityMode: plain
+    nvme:
+      path: /mnt/nvme/rawfile/
+      reservedCapacity: 20GiB
+      reservedCapacityMode: subtract-from-total
+```
+
+Apply the updated values:
+
+```bash
+helm upgrade rawfile-localpv rawfile-localpv/rawfile-localpv -n openebs -f values.yaml
+```
+
+## Pool Naming Rules
+
+Pool names must be DNS-compatible:
+- Length: 3–63 characters
+- Characters: lowercase letters, digits, and hyphens only
+- Cannot start or end with a hyphen
+
+## Reserved Capacity Modes
+
+Each pool defines how much disk space is reserved for non-pool use.
+
+| Mode | Behavior |
+|---|---|
+| `plain` | The pool grows until the specified capacity remains free on the backing filesystem. Suitable for shared disks. |
+| `subtract-from-total` | The pool is capped at `total disk size − reserved amount`. Suitable for dedicated disks. |
+
+**`plain` example:** A 1 TB disk with `reservedCapacity: "10%"` allows the pool to use up to 900 GB.
+
+**`subtract-from-total` example:** A 1 TB disk with `reservedCapacity: 20GiB` caps the pool at 980 GB regardless of other filesystem usage.
+
+## Validation Rules
+
+The driver validates pool configuration on startup:
+
+- Pool paths must exist or be creatable on each node.
+- Each pool must be on a distinct backing filesystem - multiple pools cannot share the same device.
+- The `defaultPool` must reference an existing pool entry.
+- Pool paths must be unique per node.
+
+## Copy-on-Write (CoW) Capable Pools
+
+Snapshots and clones are always available, but pools backed by CoW-capable filesystems make them fast and space-efficient (reflinks, nearly instant). Pools without CoW support perform a full data copy.
+
+| Filesystem | CoW Support |
+|---|---|
+| btrfs | Native |
+| XFS | With `mkfs.xfs -m reflink=1` |
+| ext4 | Full copy |
+
+To create an XFS pool with reflink enabled:
+
+```bash
+mkfs.xfs -m reflink=1 /dev/sdb
+mount /dev/sdb /mnt/nvme/rawfile/
+```
+
+## Create StorageClasses per Pool
+
+Create a separate StorageClass for each pool tier and reference the pool by name via the `storagePool` parameter:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-nvme
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  storagePool: nvme
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-hdd
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  storagePool: hdd
+```
+
+:::important
+`volumeBindingMode: WaitForFirstConsumer` is required. Using `Immediate` will fail with "No preferred topology set" because the driver needs to know which node the pod will land on to select the correct pool.
+:::
+
+A StorageClass without a `storagePool` parameter uses `node.defaultPool`.
+
+## Monitor Pool Capacity
+
+Pool metrics are exposed on port 9100. Use these PromQL queries to track capacity:
+
+```promql
+# Remaining capacity per pool
+rawfile_pool_remaining_capacity_bytes
+
+# Alert when a pool has less than 10 GiB free
+rawfile_pool_remaining_capacity_bytes < 10 * 1024^3
+```
+
+See [Monitoring](rawfile-monitoring.md) for the full metrics reference.
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Create StorageClass(s)](../configuration/rawfile-create-storageclass.md)
+- [StorageClass Parameters](../configuration/rawfile-storageclass-parameters.md)
+- [Monitoring](rawfile-monitoring.md)
+- [Snapshots](rawfile-snapshot.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools.md
@@ -72,7 +72,7 @@ Snapshots and clones are always available, but pools backed by CoW-capable files
 |---|---|
 | btrfs | Native |
 | XFS | With `mkfs.xfs -m reflink=1` |
-| ext4 | Full copy |
+| ext4 | No reflink support (full copy) |
 
 To create an XFS pool with reflink enabled:
 
@@ -131,7 +131,7 @@ See [Monitoring](rawfile-monitoring.md) for the full metrics reference.
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools.md
@@ -39,7 +39,7 @@ helm upgrade rawfile-localpv rawfile-localpv/rawfile-localpv -n openebs -f value
 
 Pool names must be DNS-compatible:
 - Length: 3–63 characters
-- Characters: lowercase letters, digits, and hyphens only
+- Characters: letters (uppercase or lowercase), digits, and hyphens only
 - Cannot start or end with a hyphen
 
 ## Reserved Capacity Modes

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-thin-provisioning.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-thin-provisioning.md
@@ -1,0 +1,102 @@
+---
+id: rawfile-thin-provisioning
+title: Thin Provisioning
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Thin Provisioning
+ - Overprovisioning
+description: This document explains thin provisioning with Local PV Rawfile, enabling overprovisioned volumes using sparse files.
+---
+
+By default, Local PV Rawfile creates **thick-provisioned** volumes - the backing file is fully pre-allocated at creation time. Thin provisioning uses sparse files instead, so only the blocks actually written by the application consume physical disk space.
+
+## Thick vs Thin Provisioning
+
+| Feature | Thick (default) | Thin |
+|---|---|---|
+| Backing file | Pre-allocated | Sparse (holes represent unwritten blocks) |
+| Disk usage at creation | Equal to requested size | Near zero |
+| Overprovisioning | Not possible | Possible |
+| Performance | Predictable - no allocation latency | May have small latency on first write to a block |
+| Risk | None - space is reserved | Out-of-space if physical disk fills before logical limit |
+
+## Enable Thin Provisioning
+
+Set `thinProvision: "true"` in the StorageClass parameters:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-thin
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  thinProvision: "true"
+```
+
+All PVCs created from this StorageClass will use sparse files.
+
+## Overprovisioning
+
+Thin provisioning enables you to provision more logical capacity than physical disk space. For example, on a 100 GB pool you could provision ten 20 GB volumes (200 GB logical), as long as the total data written across all volumes does not exceed the physical pool capacity.
+
+Monitor the overcommit ratio:
+
+```promql
+rawfile_pool_volumes_logical_bytes / rawfile_pool_capacity_bytes
+```
+
+:::warning
+If the underlying pool runs out of physical space, writes to thin-provisioned volumes will fail with I/O errors at the application level. Monitor `rawfile_pool_remaining_capacity_bytes` and set alerts before this occurs.
+:::
+
+## Monitor Physical vs Logical Usage
+
+```promql
+# Physical bytes actually written across all volumes in a pool
+rawfile_pool_volumes_physical_bytes
+
+# Logical (provisioned) bytes across all volumes
+rawfile_pool_volumes_logical_bytes
+
+# Space savings ratio (higher = more savings from thin provisioning or CoW)
+1 - (rawfile_pool_volumes_physical_bytes / rawfile_pool_volumes_logical_bytes)
+```
+
+Per-volume physical usage:
+
+```promql
+rawfile_volume_physical_bytes
+```
+
+## Thin Provisioning with CoW Pools
+
+Thin provisioning combines well with Copy-on-Write pools (btrfs, XFS reflink):
+
+- New volumes start near-empty (sparse file).
+- Snapshots and clones only consume the blocks that differ from their source.
+- Physical usage tracks actual data written, not logical size.
+
+## Thick Provisioning Use Cases
+
+Use thick provisioning (the default) when:
+
+- Predictable I/O performance is critical.
+- You need a guaranteed reservation of disk space for a workload.
+- The pool is shared with other services and you want to avoid unexpected out-of-space conditions.
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [StorageClass Parameters](../configuration/rawfile-storageclass-parameters.md)
+- [Monitoring](rawfile-monitoring.md)
+- [Storage Pools](rawfile-storage-pools.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-thin-provisioning.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-thin-provisioning.md
@@ -77,7 +77,7 @@ rawfile_volume_physical_bytes
 
 ## Thin Provisioning with CoW Pools
 
-Thin provisioning combines well with Copy-on-Write pools (btrfs, XFS reflink):
+Thin provisioning combines well with Copy-on-Write pools (filesystems with reflink enabled):
 
 - New volumes start near-empty (sparse file).
 - Snapshots and clones only consume the blocks that differ from their source.
@@ -93,7 +93,7 @@ Use thick provisioning (the default) when:
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-volume-restore.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-volume-restore.md
@@ -144,7 +144,7 @@ Both use the same underlying copy mechanism: cheap on CoW-capable pools, full co
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-volume-restore.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-volume-restore.md
@@ -1,0 +1,153 @@
+---
+id: rawfile-volume-restore
+title: Volume Restore (Cloning)
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Volume Restore
+ - Clone
+ - PVC Clone
+description: This document explains how to clone an existing PVC or restore a snapshot into a new PVC with Local PV Rawfile.
+---
+
+Local PV Rawfile supports two ways to create a new PVC from existing data:
+
+- **PVC Clone** - creates an independent copy of a PVC without an intermediate snapshot object.
+- **Snapshot Restore** - creates a new PVC from an existing `VolumeSnapshot`.
+
+Both are node-local: the new PVC is provisioned on the same node as the source.
+
+## PVC Clone
+
+Cloning creates a new PVC that starts as an exact copy of an existing PVC. No `VolumeSnapshot` object is created.
+
+### Requirements
+
+- Snapshots must be enabled in the chart (used internally for clone): `capabilities.snapshots.enabled=true`
+- The source pool must have roughly **3× the volume size** of free capacity while the clone is being materialized.
+- Cross-node cloning is not yet supported - source and clone must land on the same node.
+
+### Create a Clone
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data-clone
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: app-data
+  resources:
+    requests:
+      storage: 10Gi    # must be >= source size
+```
+
+```bash
+kubectl apply -f clone.yaml
+```
+
+### Consume the Clone
+
+The clone, like any rawfile PVC, is provisioned when a pod uses it (`WaitForFirstConsumer`):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-clone-consumer
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep infinity"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: app-data-clone
+```
+
+```bash
+kubectl get pvc app-data-clone -w    # wait for Bound
+kubectl exec app-clone-consumer -- ls /data
+```
+
+The clone is fully independent after creation - changes to the clone do not affect the source, and changes to the source do not affect the clone.
+
+### Clone Consistency
+
+Cloning an actively-written volume produces a crash-consistent copy at best. For consistent clones:
+
+- Use a StorageClass with `freezeFs: "true"` - the filesystem is frozen during the copy.
+- Use a CoW-capable pool (XFS with reflink, btrfs) - the copy is nearly instantaneous and consistent.
+
+:::warning
+With `freezeFs: "true"` on a **non-CoW** pool, the filesystem stays frozen for the **entire duration of the copy**. All writes to the volume block until the clone completes, which can take a long time for large volumes. Prefer a CoW-capable pool.
+:::
+
+If neither `freezeFs` nor a CoW pool is available and the volume is actively written, the clone request will be rejected. Scale the workload down first.
+
+## Snapshot Restore
+
+Restore a previously taken snapshot into a new PVC by specifying it as a `dataSource`.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data-restored
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  dataSource:
+    name: app-data-snap
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+```bash
+kubectl apply -f restore.yaml
+kubectl get pvc app-data-restored -w
+```
+
+The restored PVC will land on the same node that holds the snapshot data.
+
+## Clone vs. Snapshot Restore
+
+| Feature | PVC Clone | Snapshot Restore |
+|---|---|---|
+| Point-in-time copy kept around | No - one-shot copy | Yes - snapshot object persists |
+| Extra API objects needed | None | `VolumeSnapshot` + `VolumeSnapshotClass` |
+| Use case | Duplicate an environment, fork test data | Backup/rollback points, repeated restores |
+
+Both use the same underlying copy mechanism: cheap on CoW-capable pools, full copy otherwise.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Insufficient disk space (Cloning a volume requires at least 3× the volume size)` | Free capacity on the source node's pool, or grow the underlying disk. |
+| Clone PVC stuck in `Pending` | Needs a consuming pod (`WaitForFirstConsumer`). Check `kubectl describe pvc` events. |
+| `Snapshotting capabilities are disabled` | Enable `capabilities.snapshots.enabled=true` and upgrade the Helm release. |
+| Clone must land on a different node | Not yet supported - cross-node cloning is in progress. |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Snapshots](rawfile-snapshot.md)
+- [Storage Pools](rawfile-storage-pools.md)
+- [Create PVC](../configuration/rawfile-create-pvc.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-pvc.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-pvc.md
@@ -1,0 +1,180 @@
+---
+id: rawfile-create-pvc
+title: Create PersistentVolumeClaim
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Configuration
+ - Create PVC
+ - Create PersistentVolumeClaim
+description: This document provides step-by-step instructions to create a PersistentVolumeClaim (PVC) using the Local PV Rawfile storage class.
+---
+
+# Create PersistentVolumeClaim
+
+This document provides step-by-step instructions to create a PersistentVolumeClaim (PVC) using the Local PV Rawfile storage class. It covers filesystem mode and block mode PVCs, how to verify binding, how to consume the volume in a pod, and how to delete volumes.
+
+Before you begin, make sure:
+
+- The Rawfile driver is installed and running. Refer to the [Installation](../../../../quickstart-guide/installation.md) documentation for more information.
+- A StorageClass exists. The Helm chart creates one named `rawfile-localpv` by default:
+
+  ```bash
+  kubectl get sc rawfile-localpv
+  ```
+
+## Create a Filesystem Mode PVC
+
+This is the default volume mode. The driver formats the backing file with the filesystem specified in the StorageClass and mounts it as a directory inside the pod.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rawfile-pvc
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+Apply the PVC:
+
+```bash
+kubectl apply -f pvc.yaml
+```
+
+The PVC will remain in `Pending` state until a pod that uses it is scheduled. This is expected behavior with `volumeBindingMode: WaitForFirstConsumer`.
+
+```bash
+kubectl get pvc rawfile-pvc
+```
+
+## Create a Block Mode PVC
+
+For workloads that manage their own storage format (e.g. databases), use `volumeMode: Block`. The driver exposes the loop device directly to the pod without formatting.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rawfile-block-pvc
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+:::note
+`fsType`, `formatOptions`, and `mountOptions` StorageClass parameters are ignored for block mode PVCs. The `readOnly` attribute on block PVCs is not currently honored.
+:::
+
+## Consume the Volume in a Pod
+
+### Filesystem Mode
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep infinity"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rawfile-pvc
+```
+
+Once the pod is scheduled, the driver provisions the volume on that node and the PVC transitions to `Bound`:
+
+```bash
+kubectl get pvc rawfile-pvc
+```
+
+Verify the volume inside the pod:
+
+```bash
+kubectl exec app -- df -hT /data
+```
+
+### Block Mode
+
+Use `volumeDevices` instead of `volumeMounts` to consume a block PVC:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-block
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep infinity"]
+      volumeDevices:
+        - name: data
+          devicePath: /dev/xvda
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rawfile-block-pvc
+```
+
+## PVC Parameters Reference
+
+| Parameter | Required | Values | Notes |
+|---|---|---|---|
+| `storageClassName` | Yes | Rawfile StorageClass name | Must reference a StorageClass with `rawfile.csi.openebs.io` provisioner |
+| `accessModes` | Yes | `ReadWriteOnce` | Only `ReadWriteOnce` is supported |
+| `resources.requests.storage` | Yes | e.g. `10Gi`, `100Gi` | Provisioning fails if the pool lacks sufficient free capacity |
+| `volumeMode` | No | `Filesystem` (default) / `Block` | `Block` exposes a raw loop device; formatting is skipped |
+| `dataSource` (VolumeSnapshot) | No | VolumeSnapshot reference | Restores a snapshot into a new PVC — see [Snapshots](../advanced-operations/rawfile-snapshot.md) |
+| `dataSource` (PVC clone) | No | PVC reference | Clones an existing PVC — see [Volume Restore](../advanced-operations/rawfile-volume-restore.md) |
+
+## Deprovisioning
+
+Delete the workload using the PVC first, then delete the PVC:
+
+```bash
+kubectl delete pod app
+kubectl delete pvc rawfile-pvc
+```
+
+With `reclaimPolicy: Delete` (default), the PV, backing file, and metadata are removed from the node. With `Retain`, the PV and data remain until you delete the PV manually.
+
+:::important
+Delete any VolumeSnapshots of a volume before deleting the volume itself if you intend to fully reclaim space.
+:::
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| PVC `Pending` forever | Is a pod consuming it? Check pool capacity: `kubectl get csistoragecapacities -A`. Check events: `kubectl describe pvc <name>`. |
+| `Invalid storage pool` error | The `storagePool` parameter in the StorageClass does not match a configured pool on the node. |
+| Pod stuck in `ContainerCreating` | Check node plugin logs: `kubectl -n openebs logs ds/<release>-node -c csi-driver`. |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../../quickstart-guide/installation.md)
+- [Create StorageClass(s)](rawfile-create-storageclass.md)
+- [StorageClass Parameters](rawfile-storageclass-parameters.md)
+- [Deploy an Application](rawfile-deployment.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-pvc.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-pvc.md
@@ -170,7 +170,7 @@ Delete any VolumeSnapshots of a volume before deleting the volume itself if you 
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-storageclass.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-storageclass.md
@@ -1,4 +1,4 @@
----
+﻿---
 id: rawfile-create-storageclass
 title: Create StorageClass(s)
 keywords:
@@ -221,7 +221,7 @@ There are no driver-specific parameters on the `VolumeSnapshotClass`. Snapshot b
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-storageclass.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-storageclass.md
@@ -1,0 +1,230 @@
+---
+id: rawfile-create-storageclass
+title: Create StorageClass(s)
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Configuration
+ - Create StorageClass
+ - Create Local PV Rawfile StorageClass(s)
+description: This guide will help you to create Local PV Rawfile StorageClass.
+---
+
+# Create StorageClass(s)
+
+This document provides step-by-step instructions on creating a StorageClass for Local PV Rawfile, with examples covering different filesystem types, thin provisioning, and volume binding modes.
+
+The provisioner name for Local PV Rawfile is `rawfile.csi.openebs.io`. This must be set in every StorageClass so that provisioning requests are handled by the Rawfile driver.
+
+:::important
+Always set `volumeBindingMode: WaitForFirstConsumer`. The driver provisions volumes on the node chosen by the Kubernetes scheduler and requires that topology information. Using `Immediate` will cause provisioning to fail with "No preferred topology set".
+:::
+
+## Default StorageClass (ext4)
+
+The following is a basic StorageClass that provisions volumes formatted with ext4, which is the default filesystem:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-ext4
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+```
+
+## StorageClass with XFS
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-xfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "xfs"
+```
+
+## StorageClass with Btrfs
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-btrfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "btrfs"
+```
+
+## StorageClass with Thin Provisioning
+
+By default, volumes are **thick-provisioned** - the full backing file is pre-allocated at creation time. Thin provisioning creates a sparse backing file instead, meaning disk space is allocated on demand as data is written. This enables overprovisioning, so you must monitor actual pool usage (`rawfile_pool_remaining_capacity_bytes`) to avoid the backing filesystem running out of space.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-thin
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+  thinProvision: "true"
+  formatOptions: "-E nodiscard"
+```
+
+:::note
+For ext4 volumes, 5% of the capacity is reserved for the root user by default. To remove this reservation and make the full capacity available to applications, add `-m 0` to `formatOptions`:
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+  formatOptions: "-m 0"
+```
+:::
+
+## StorageClass with Snapshots Enabled (Copy-on-Write)
+
+To enable block-level snapshots using copy-on-write (reflink), set `copyOnWrite` to `"true"`. The underlying storage pool's filesystem must support reflinks. CoW support varies by filesystem:
+
+| Filesystem | CoW Support | Setup Required |
+|---|---|---|
+| btrfs | Native | None - works out of the box |
+| XFS | With reflink | Format the pool device with `mkfs.xfs -m reflink=1` |
+| ext4 | Not supported | Full data copy is used instead |
+
+**For btrfs** - no extra setup needed, just set `fstype: btrfs`:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-cow-btrfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "btrfs"
+  copyOnWrite: "true"
+```
+
+**For XFS**, format the pool device with reflink enabled on each node, then configure the pool path in Helm values:
+
+```bash
+mkfs.xfs -m reflink=1 /dev/sdb
+mount /dev/sdb /mnt/nvme/rawfile/
+```
+
+Create a StorageClass targeting that pool:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-cow-xfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "xfs"
+  copyOnWrite: "true"
+  storagePool: "nvme"
+```
+
+See [Storage Pools](../advanced-operations/rawfile-storage-pools.md) for how to configure the pool in Helm values.
+
+## StorageClass with FreezeFS for In-Use Snapshots
+
+For volumes that need to be snapshotted while in use and where CoW is not available, enable `freezeFs`. This briefly freezes the filesystem during snapshot creation to ensure consistency.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-freezefs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+  freezeFs: "true"
+```
+
+## StorageClass Targeting a Specific Storage Pool
+
+Storage pools must be configured in the Helm chart before they can be referenced in a StorageClass. See [Storage Pools](../advanced-operations/rawfile-storage-pools.md) for how to define named pools with independent paths and capacity reservations.
+
+Once pools are configured, use the `storagePool` parameter to pin volumes to a named pool:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-fast-pool
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+  storagePool: "fast-pool"
+```
+
+:::note
+To use the node's default pool, omit the `storagePool` key entirely. Setting it to an empty string (`""`) is rejected as an invalid pool name.
+:::
+
+## VolumeSnapshotClass
+
+To use snapshots with Local PV Rawfile, a `VolumeSnapshotClass` is required. The Helm chart creates one named `rawfile-localpv` by default. To create one manually:
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: rawfile-localpv
+driver: rawfile.csi.openebs.io
+deletionPolicy: Delete
+```
+
+There are no driver-specific parameters on the `VolumeSnapshotClass`. Snapshot behavior (`freezeFs`, `copyOnWrite`) is controlled by the volume's StorageClass.
+
+## StorageClass Parameters Conformance Matrix
+
+### Standard StorageClass Parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `allowVolumeExpansion` | `true` / `false` | Set to `true` to enable online volume resize |
+| `volumeBindingMode` | `WaitForFirstConsumer` | **Required.** `Immediate` causes provisioning to fail |
+| `reclaimPolicy` | `Retain` / `Delete` | `Delete` removes the backing file when the PV is released |
+
+### Rawfile-Specific StorageClass Parameters
+
+| Parameter | Values | Description |
+|---|---|---|
+| `csi.storage.k8s.io/fstype` | `ext4` (default), `xfs`, `btrfs` | Filesystem used to format the volume; ignored for `volumeMode: Block` |
+| `thinProvision` | `"true"` / `"false"` (default) | `"true"` creates a sparse backing file; enables overprovisioning - monitor pool usage |
+| `copyOnWrite` | `"true"` / `"false"` / unset | CoW reflink attribute on the backing file; leave unset to autodetect per pool |
+| `freezeFs` | `"true"` / `"false"` (default) | Briefly freezes the filesystem during snapshots of in-use volumes for consistency |
+| `formatOptions` | Extra `mkfs` flags (e.g. `"-m 0"`, `"-i maxpct=10"`) | Applied once at volume creation time only |
+| `mountOptions` | Mount flags (e.g. `noatime`) | Passed to `mount` when attaching the volume to a pod |
+| `storagePool` | Pool name string | Targets a named storage pool; omit the key entirely for the node's default pool |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../../quickstart-guide/installation.md)
+- [StorageClass Parameters](rawfile-storageclass-parameters.md)
+- [Create PVC](rawfile-create-pvc.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment.md
@@ -1,4 +1,4 @@
----
+﻿---
 id: rawfile-deployment
 title: Deploy an Application
 keywords:
@@ -61,7 +61,7 @@ The following matrix shows the supported PersistentVolumeClaim parameters for Lo
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment.md
@@ -1,0 +1,71 @@
+---
+id: rawfile-deployment
+title: Deploy an Application
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Configuration
+ - Deploy an Application
+description: This section explains the instructions to deploy an application for the OpenEBS Local Persistent Volumes (PV) backed by Local PV Rawfile storage.
+---
+
+This document explains the instructions to deploy an application for the OpenEBS Local Persistent Volumes (PV) backed by Local PV Rawfile storage.
+
+Create the deployment using the PVC backed by Local PV Rawfile storage.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "while true; do sleep 60; done"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rawfile-pvc
+```
+
+After the deployment of the application, the node will attach the loop device, format it with the configured filesystem, and mount it into the pod. You can verify the volume is in use:
+
+```bash
+kubectl get pvc rawfile-pvc
+kubectl exec app -- df -hT /data
+```
+
+**Sample Output**
+
+```
+Filesystem     Type  Size  Used Avail Use% Mounted on
+/dev/loop3     ext4   10G   24K  9.5G   1% /data
+```
+
+## PersistentVolumeClaim Conformance Matrix
+
+The following matrix shows the supported PersistentVolumeClaim parameters for Local PV Rawfile.
+
+| Parameter | Values |
+|---|---|
+| `accessModes` | Supported: `ReadWriteOnce` / Not Supported: `ReadWriteMany`, `ReadOnlyMany` |
+| `storageClassName` | StorageClass name |
+| `resources.requests.storage` | Storage size with unit (e.g. `10Gi`, `100Gi`) |
+| `volumeMode` | `Filesystem` (default), `Block` |
+| `dataSource` (VolumeSnapshot) | Supported - restores a snapshot into a new PVC |
+| `dataSource` (PVC clone) | Supported - clones an existing same-node PVC |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../../quickstart-guide/installation.md)
+- [Create StorageClass(s)](rawfile-create-storageclass.md)
+- [StorageClass Parameters](rawfile-storageclass-parameters.md)
+- [Create PVC](rawfile-create-pvc.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-storageclass-parameters.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-storageclass-parameters.md
@@ -203,7 +203,7 @@ Controls what happens to the backing file and PV when the PVC is deleted.
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-storageclass-parameters.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-storageclass-parameters.md
@@ -1,0 +1,213 @@
+---
+id: rawfile-storageclass-parameters
+title: StorageClass Parameters
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Configuration
+ - StorageClass Parameters
+ - StorageClass Options
+description: This guide describes all supported StorageClass parameters for Local PV Rawfile.
+---
+
+# StorageClass Parameters
+
+This document describes all supported StorageClass parameters for Local PV Rawfile and explains how to configure them. These parameters control filesystem selection, provisioning behavior, snapshot support, mount options, and storage pool targeting.
+
+## fstype (Optional)
+
+Specifies the filesystem used to format the volume. If unspecified, falls back to the node plugin's `defaultFs` (chart value `node.defaultFs`, default `ext4`). Ignored for `volumeMode: Block` PVCs.
+
+Supported values: `ext4` (default), `xfs`, `btrfs`.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-xfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+```
+
+:::note
+Parameter keys are matched case-insensitively by the driver. Values must be strings - quote booleans (e.g. `"true"`, `"false"`).
+:::
+
+## thinProvision (Optional)
+
+Controls whether the backing file is pre-allocated (thick) or sparse (thin).
+
+- **`"false"` (default)** - Thick provisioning. The full backing file is allocated at volume creation time. Space is consumed from the pool upfront and overprovisioning is not possible.
+- **`"true"`** - Thin provisioning. A sparse backing file is created and disk space is allocated on write. This enables overprovisioning, so you must monitor real pool usage (`rawfile_pool_remaining_capacity_bytes`) to avoid running the backing filesystem out of space.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-thin
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  thinProvision: "true"
+```
+
+## formatOptions (Optional)
+
+Extra flags passed to `mkfs.<fstype>` when the volume is formatted at creation time. Applied only once at first format - not on subsequent mounts.
+
+Examples:
+- ext4: `"-m 0"` removes the 5% root-reserved block reservation, making the full capacity available to applications.
+- xfs: `"-i maxpct=10"` limits inode space.
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  formatOptions: "-m 0"
+```
+
+:::note
+In Helm chart values, `formatOptions` is a list that is joined with spaces at runtime:
+```yaml
+storageClasses:
+  - name: rawfile-localpv
+    formatOptions: ["-m", "0"]
+```
+:::
+
+## copyOnWrite (Optional)
+
+Controls the copy-on-write (reflink) attribute on the volume's backing file.
+
+- **Unset (recommended)** - The driver autodetects CoW support on each pool's backing filesystem and applies it accordingly.
+- **`"true"`** - Explicitly enable CoW. The pool's backing filesystem must support reflinks (btrfs natively, or XFS created with `mkfs.xfs -m reflink=1`).
+- **`"false"`** - Explicitly disable CoW. Useful for database workloads where `nodatacow` improves write performance.
+
+When CoW is enabled, snapshots and clones are cheap (reflink copy). Without CoW, snapshots perform a full data copy.
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  copyOnWrite: "true"
+```
+
+## freezeFs (Optional)
+
+- **`"false"` (default)** - No filesystem freeze during snapshot.
+- **`"true"`** - The volume's filesystem is briefly frozen (`fsfreeze`) while a snapshot of an in-use volume is taken, producing a crash-consistent image.
+
+Use this when the pool's backing filesystem does not support CoW and you need consistent snapshots of running volumes. Expect a brief I/O pause on the volume during snapshot creation.
+
+:::important
+On a non-CoW pool with `freezeFs: "true"`, the filesystem stays frozen for the **entire duration of the data copy**. For large volumes this can be significant. Prefer a CoW-capable pool filesystem where possible.
+:::
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  copyOnWrite: "false"
+  freezeFs: "true"
+```
+
+## mountOptions (Optional)
+
+Mount flags passed to the `mount` command when the volume is attached to a pod. If unspecified, `-o default` is used.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-noatime
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+mountOptions:
+  - noatime
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+```
+
+:::note
+Mount options are not validated by the driver. If mount options are invalid, the volume mount will fail.
+:::
+
+## storagePool (Optional)
+
+Targets a specific named storage pool on the node. If omitted, the node's `defaultPool` is used.
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  storagePool: nvme
+```
+
+:::important
+Omit the `storagePool` key entirely to use the default pool. Setting it to an empty string (`""`) is rejected as an invalid pool name.
+:::
+
+Provisioning fails with `INVALID_ARGUMENT` if the named pool does not exist on the selected node.
+
+## volumeBindingMode (Required)
+
+:::important
+Always use `WaitForFirstConsumer`. The driver requires the node topology set by the Kubernetes scheduler to provision a volume. Using `Immediate` fails with "No preferred topology set".
+:::
+
+| Value | Behavior |
+|---|---|
+| `WaitForFirstConsumer` | Volume is provisioned when a pod using the PVC is scheduled - node is chosen by the scheduler |
+| `Immediate` | Not supported - provisioning fails |
+
+## allowVolumeExpansion (Optional)
+
+Set to `true` to enable online volume expansion. Requires `capabilities.resize.enabled=true` in the Helm chart (default). Supported for ext4, xfs, and btrfs. Shrinking is not supported.
+
+```yaml
+allowVolumeExpansion: true
+```
+
+## reclaimPolicy (Optional)
+
+Controls what happens to the backing file and PV when the PVC is deleted.
+
+| Value | Behavior |
+|---|---|
+| `Delete` (default) | The PV and its backing file are deleted when the PVC is released |
+| `Retain` | The PV and backing file are kept until manually deleted |
+
+## StorageClass Parameters Conformance Matrix
+
+### Standard Parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `volumeBindingMode` | `WaitForFirstConsumer` | **Required.** `Immediate` causes provisioning to fail |
+| `allowVolumeExpansion` | `true` / `false` | Enable online resize |
+| `reclaimPolicy` | `Delete` (default) / `Retain` | Backing file lifecycle on PVC deletion |
+| `mountOptions` | Mount flags | Not validated - invalid options cause mount failure |
+
+### Rawfile-Specific Parameters
+
+| Parameter | Default | Values | Description |
+|---|---|---|---|
+| `csi.storage.k8s.io/fstype` | `ext4` | `ext4`, `xfs`, `btrfs` | Volume filesystem type |
+| `thinProvision` | `"false"` | `"true"` / `"false"` | Sparse vs pre-allocated backing file |
+| `formatOptions` | - | `mkfs` flags string | Applied once at volume creation |
+| `copyOnWrite` | autodetect | `"true"` / `"false"` / unset | CoW attribute on backing file |
+| `freezeFs` | `"false"` | `"true"` / `"false"` | Freeze filesystem during in-use snapshots |
+| `storagePool` | node default | Pool name string | Target a named storage pool |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../../quickstart-guide/installation.md)
+- [Create StorageClass(s)](rawfile-create-storageclass.md)
+- [Create PVC](rawfile-create-pvc.md)
+- [Storage Pools](../advanced-operations/rawfile-storage-pools.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview.md
@@ -1,0 +1,44 @@
+---
+id: rawfile-overview
+title: Local PV Rawfile Overview
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile Overview
+ - Installation
+ - Prerequisites
+description: This section explains the overview of Local PV Rawfile.
+---
+
+OpenEBS Local PV Rawfile provisions persistent volumes backed by raw files on the host filesystem, exposed to pods as independent block devices via Linux loop devices. Each volume is a thick or thin-provisioned file formatted with its own filesystem (`ext4`, `btrfs`, or `xfs`), making it fully isolated from the host's filesystem. This approach delivers near-baremetal disk performance with hard-enforced capacity limits, real-time volume metrics, and per-volume filesystem customization - addressing the core limitations of HostPath-based provisioning.
+
+## How It Works
+
+When a PVC is created, the driver allocates a raw file in a configured storage pool directory on the selected node and attaches it to a Linux loop device. That loop device is then formatted with the requested filesystem and mounted into the pod. Since each volume is an independent block device, the operating system enforces size limits natively and usage metrics are available in O(1) via `df`.
+
+The driver runs as a DaemonSet node plugin on every eligible node, handling both CSI Node and Controller operations locally. When volume resize is enabled, a separate controller Deployment manages cluster-wide resize requests. Long-running operations such as volume creation and snapshot creation are handled asynchronously by a built-in Task Manager, which persists state so that operations survive driver restarts and are retried automatically on failure.
+
+Volumes are strictly node-local - the Kubernetes scheduler uses storage capacity tracking to place pods only on nodes with sufficient pool space, and once a PV is created its node affinity is permanent.
+
+## Installation
+
+Refer to the [OpenEBS Installation documentation](../../../quickstart-guide/installation.md) to install Local PV Rawfile.
+
+## Advantages
+
+- Near-baremetal disk performance – Direct I/O via loop devices with near-zero overhead.
+- Hard-enforced volume size limits – Capacity is enforced by the OS, not just advisory quotas.
+- Real-time volume usage metrics – Per-volume disk usage readable in O(1) via `df`, with Prometheus metrics exposed per pool and node.
+- Per-volume filesystem customization – Each volume can use a different filesystem (ext4, btrfs, xfs) with independent format and mount options.
+- Dynamic provisioning – Volumes are created on demand without manual pre-allocation.
+- Volume snapshots and cloning – Block-level copy-on-write snapshots and same-node volume cloning.
+- Online volume expansion – Expand volumes without downtime on supported filesystems (ext4, btrfs, xfs).
+- Multiple storage pools per node – Independent pool configuration with reserved capacity management.
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../quickstart-guide/installation.md)
+- [Deploy an Application](../../../quickstart-guide/deploy-a-test-application.md)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview.md
@@ -30,7 +30,7 @@ Refer to the [OpenEBS Installation documentation](../../../quickstart-guide/inst
 - Real-time volume usage metrics – Per-volume disk usage readable in O(1) via `df`, with Prometheus metrics exposed per pool and node.
 - Per-volume filesystem customization – Each volume can use a different filesystem (ext4, btrfs, xfs) with independent format and mount options.
 - Dynamic provisioning – Volumes are created on demand without manual pre-allocation.
-- Volume snapshots and cloning – Block-level copy-on-write snapshots and same-node volume cloning.
+- Volume snapshots and cloning – Block-level copy-on-write snapshots and same-node volume cloning (CoW efficiency depends on the underlying pool filesystem — see [Storage Pools](advanced-operations/rawfile-storage-pools.md)).
 - Online volume expansion – Expand volumes without downtime on supported filesystems (ext4, btrfs, xfs).
 - Multiple storage pools per node – Independent pool configuration with reserved capacity management.
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview.md
@@ -36,7 +36,7 @@ Refer to the [OpenEBS Installation documentation](../../../quickstart-guide/inst
 
 ## Support
 
-If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/openebs/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
 
 ## See Also
 

--- a/docs/main/user-guides/uninstallation.md
+++ b/docs/main/user-guides/uninstallation.md
@@ -30,6 +30,26 @@ Run the following command to uninstall OpenEBS:
 helm uninstall openebs -n <OPENEBS_NAMESPACE>
 ```
 
+## Uninstalling Local PV Rawfile
+
+Local PV Rawfile is a separate Helm release and must be uninstalled independently. Before uninstalling, you must delete all resources created through the driver in the following order to avoid leaked loop device mounts on nodes:
+
+1. Delete all VolumeSnapshots
+2. Delete all PersistentVolumeClaims
+3. Delete all PersistentVolumes
+
+Then uninstall the Helm release:
+
+```
+helm uninstall rawfile-localpv -n openebs
+```
+
+After uninstalling, you may want to remove the rawfile data directory from each node manually (default: `/var/csi/rawfile`).
+
+:::warning
+If you uninstall the driver without first deleting the above resources, loop devices and mounts may be left behind on the nodes and require manual cleanup.
+:::
+
 :::note
 Uninstalling the Helm chart does not remove/uninstall the CustomResourceDefinitions (CRDs).
 

--- a/docs/main/user-guides/upgrades.md
+++ b/docs/main/user-guides/upgrades.md
@@ -15,7 +15,8 @@ This document describes the procedure for upgrading an existing OpenEBS deployme
 This upgrade process allows you to upgrade to the latest OpenEBS version 4.5 which is a unified installer for three Local Storages (a.k.a Local Engines):
 - Local PV HostPath
 - Local PV LVM 
-- Local PV ZFS 
+- Local PV ZFS
+- Local PV Rawfile
 
 and one Replicated Storage (a.k.a Replicated Engine):
 - Replicated PV Mayastor
@@ -41,6 +42,7 @@ Downgrades are not supported.
     - Local PV Hostpath
     - Local PV LVM
     - Local PV ZFS
+    - Local PV Rawfile
     - Replicated PV Mayastor
 
 Refer to the [Migration documentation](../user-guides/data-migration/migration-overview.md) for other storages.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -424,6 +424,108 @@ const sidebars: SidebarsConfig =
             {
               collapsed: true,
               type: "category",
+              label: "Local PV Rawfile",
+              customProps: {
+                icon: "Book"
+              },
+              items: [
+                {
+                  type: "doc",
+                  id: "user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview",
+                  label: "Overview",
+                  key: "Rawfile_Overview",
+                },
+                {
+                  collapsed: true,
+                  type: "category",
+                  label: "Configuration",
+                  key: "Rawfile_Configuration",
+                  customProps: {
+                    icon: "Settings"
+                  },
+                  items: [
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-storageclass",
+                      label: "Create StorageClass(s)",
+                      key: "rawfile-create-storageclass",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-storageclass-parameters",
+                      label: "StorageClass Parameters",
+                      key: "rawfile-storageclass-parameters",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-pvc",
+                      label: "Create PVC",
+                      key: "rawfile-create-pvc",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment",
+                      label: "Deploy an Application",
+                      key: "rawfile-deployment",
+                    },
+                  ]
+                },
+                {
+                  collapsed: true,
+                  type: "category",
+                  label: "Advanced Operations",
+                  key: "Rawfile_AdvancedOperations",
+                  customProps: { icon: "Beaker" },
+                  items: [
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools",
+                      label: "Storage Pools",
+                      key: "rawfile-storage-pools",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-snapshot",
+                      label: "Snapshots",
+                      key: "rawfile-snapshot",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-volume-restore",
+                      label: "Volume Restore (Cloning)",
+                      key: "rawfile-volume-restore",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-resize",
+                      label: "Volume Resize",
+                      key: "rawfile-resize",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring",
+                      label: "Monitoring",
+                      key: "rawfile-monitoring",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-raw-block-volume",
+                      label: "Raw Block Volumes",
+                      key: "rawfile-raw-block-volume",
+                    },
+                    {
+                      type: "doc",
+                      id: "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-thin-provisioning",
+                      label: "Thin Provisioning",
+                      key: "rawfile-thin-provisioning",
+                    },
+                  ]
+                },
+              ]
+            },
+            {
+              collapsed: true,
+              type: "category",
               label: "Additional Information",
               key: "Main_AdditionalInformation",
               customProps: {

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring.md
@@ -1,0 +1,133 @@
+﻿---
+id: rawfile-monitoring
+title: Monitoring
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Monitoring
+ - Prometheus
+ - Metrics
+description: This document describes the Prometheus metrics exposed by Local PV Rawfile and how to configure scraping.
+---
+
+Local PV Rawfile exposes Prometheus metrics from the node plugin on each node. Metrics are organized at three levels: node, pool, and volume.
+
+## Enable Metrics
+
+Metrics are enabled by default. To disable them:
+
+```yaml
+metrics:
+  enabled: false
+```
+
+Metrics are exposed on port **9100** (configurable).
+
+## Configure Prometheus Scraping
+
+### Prometheus Operator (ServiceMonitor)
+
+Enable the ServiceMonitor for automatic scraping:
+
+```yaml
+metrics:
+  serviceMonitor:
+    enabled: true
+    interval: 1m
+```
+
+Apply:
+
+```bash
+helm upgrade rawfile-localpv rawfile-localpv/rawfile-localpv -n openebs \
+  --set metrics.serviceMonitor.enabled=true
+```
+
+### Manual Scraping
+
+Add a scrape job to your Prometheus configuration:
+
+```yaml
+scrape_configs:
+  - job_name: rawfile-localpv
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: [openebs]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        regex: rawfile-localpv-node
+        action: keep
+      - source_labels: [__address__]
+        target_label: __address__
+        replacement: $1:9100
+```
+
+## Metrics Reference
+
+### Node-Level Metrics
+
+| Metric | Labels | Description |
+|---|---|---|
+| `rawfile_remaining_capacity_bytes` | `node` | Free capacity for new volumes on this node, excluding reserved storage |
+
+### Pool-Level Metrics
+
+| Metric | Labels | Description |
+|---|---|---|
+| `rawfile_pool_capacity_bytes` | `node`, `pool` | Maximum usable capacity of the pool |
+| `rawfile_pool_remaining_capacity_bytes` | `node`, `pool` | Remaining free capacity in the pool |
+| `rawfile_pool_reserved_capacity_bytes` | `node`, `pool` | Capacity reserved for non-pool use |
+| `rawfile_pool_backing_fs_capacity_bytes` | `node`, `pool` | Total capacity of the backing filesystem |
+| `rawfile_pool_backing_fs_available_bytes` | `node`, `pool` | Available bytes on the backing filesystem |
+| `rawfile_pool_backing_fs_usage_bytes` | `node`, `pool` | Used bytes on the backing filesystem |
+| `rawfile_pool_volumes_physical_bytes` | `node`, `pool` | Physical disk bytes consumed by all volumes in the pool |
+| `rawfile_pool_volumes_logical_bytes` | `node`, `pool` | Logical (provisioned) bytes of all volumes in the pool |
+| `rawfile_pool_volume_count` | `node`, `pool` | Number of volumes in the pool |
+| `rawfile_pool_info` | `node`, `pool`, `mode`, `default_pool` | Pool metadata (labels only, value always 1) |
+
+### Volume-Level Metrics
+
+| Metric | Labels | Description |
+|---|---|---|
+| `rawfile_volume_used_bytes` | `node`, `volume` | Bytes currently used inside the volume |
+| `rawfile_volume_total_bytes` | `node`, `volume` | Total provisioned size of the volume |
+| `rawfile_volume_physical_bytes` | `node`, `volume` | Physical disk bytes consumed by the volume (may differ from logical for thin or CoW volumes) |
+| `rawfile_volume_info` | `node`, `volume`, `pool`, `sparse`, `thin_provision` | Volume metadata (labels only, value always 1) |
+
+## Example PromQL Queries
+
+**Alert when a volume is more than 90% full:**
+
+```promql
+rawfile_volume_used_bytes / rawfile_volume_total_bytes > 0.9
+```
+
+**Alert when a pool has less than 10 GiB free:**
+
+```promql
+rawfile_pool_remaining_capacity_bytes < 10 * 1024^3
+```
+
+**Thin-provisioning overcommit ratio per pool:**
+
+```promql
+rawfile_pool_volumes_logical_bytes / rawfile_pool_capacity_bytes
+```
+
+**Physical vs. logical usage per pool (CoW space savings):**
+
+```promql
+1 - (rawfile_pool_volumes_physical_bytes / rawfile_pool_volumes_logical_bytes)
+```
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Storage Pools](rawfile-storage-pools.md)
+- [Volume Resize](rawfile-resize.md)
+- [Thin Provisioning](rawfile-thin-provisioning.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-raw-block-volume.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-raw-block-volume.md
@@ -1,0 +1,115 @@
+﻿---
+id: rawfile-raw-block-volume
+title: Raw Block Volumes
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Raw Block Volume
+ - Block Mode
+description: This document explains how to use Local PV Rawfile volumes in raw block mode for workloads that manage their own storage format.
+---
+
+Local PV Rawfile supports raw block volumes that expose a loop device directly to the pod without any filesystem layer. This is useful for databases and other workloads that manage their own storage format.
+
+## Create a Block Mode PVC
+
+Set `volumeMode: Block` in the PVC spec:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rawfile-block-pvc
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+```bash
+kubectl apply -f block-pvc.yaml
+```
+
+The PVC will remain in `Pending` state until a consuming pod is scheduled (`WaitForFirstConsumer`).
+
+## Consume the Block Volume in a Pod
+
+Use `volumeDevices` (not `volumeMounts`) to map the raw device into the pod:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-block
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep infinity"]
+      volumeDevices:
+        - name: data
+          devicePath: /dev/xvda
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rawfile-block-pvc
+```
+
+```bash
+kubectl apply -f pod-block.yaml
+kubectl get pvc rawfile-block-pvc
+```
+
+Once the pod is scheduled, the loop device is attached and exposed at `/dev/xvda` inside the container. The application is responsible for initializing and managing the device.
+
+## Verify the Block Device
+
+```bash
+kubectl exec app-block -- ls -l /dev/xvda
+# brw-rw---- 1 root disk 7, 3 ... /dev/xvda
+
+kubectl exec app-block -- blockdev --getsize64 /dev/xvda
+# 10737418240
+```
+
+## StorageClass Parameters for Block Mode
+
+The following StorageClass parameters are **ignored** for block mode PVCs:
+
+- `csi.storage.k8s.io/fstype` - no filesystem is created
+- `formatOptions` - no format step
+- `mountOptions` - no mount step
+- `copyOnWrite` / `freezeFs` - CoW and freeze apply to filesystem operations only
+
+All other parameters (`storagePool`, `thinProvision`, `allowVolumeExpansion`) continue to apply.
+
+:::note
+The `readOnly` attribute on block mode PVCs is not currently honored.
+:::
+
+## Volume Expansion
+
+Block mode volumes support online expansion. If the volume is currently unstaged (no pod using it), only the backing file is grown; node-side expansion is deferred until the volume is next attached. The application inside the pod is responsible for recognizing the larger device (e.g. re-reading partition tables, resizing the filesystem it manages).
+
+## Use Cases
+
+| Use Case | Why Block Mode |
+|---|---|
+| Databases (PostgreSQL, MySQL) | Direct I/O without filesystem overhead |
+| VM disk images | Raw block device maps naturally to a virtual disk |
+| Custom storage formats | Application manages its own layout on the device |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Create PVC](../configuration/rawfile-create-pvc.md)
+- [StorageClass Parameters](../configuration/rawfile-storageclass-parameters.md)
+- [Volume Resize](rawfile-resize.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-resize.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-resize.md
@@ -1,0 +1,124 @@
+---
+id: rawfile-resize
+title: Volume Resize
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Volume Resize
+ - Volume Expansion
+description: This document explains how to expand Local PV Rawfile volumes online without restarting the pod.
+---
+
+Local PV Rawfile supports **online volume expansion** - the backing file, loop device, and filesystem are grown live with no pod restart required. Shrinking is not supported.
+
+## Requirements
+
+- Resize must be enabled in the chart (default): `capabilities.resize.enabled=true`
+- The StorageClass must set `allowVolumeExpansion: true`
+- Online filesystem growth is supported for `ext4`, `xfs`, and `btrfs`
+- Sufficient free capacity must exist in the volume's storage pool on its node
+
+## StorageClass Configuration
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-localpv
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+```
+
+## Expand a Volume
+
+Edit the PVC's `spec.resources.requests.storage` to the new (larger) size:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi    # was 10Gi
+```
+
+```bash
+kubectl apply -f pvc.yaml
+```
+
+Or patch in place:
+
+```bash
+kubectl patch pvc app-data \
+  -p '{"spec":{"resources":{"requests":{"storage":"20Gi"}}}}'
+```
+
+## Monitor the Expansion
+
+Watch for the capacity to update:
+
+```bash
+kubectl get pvc app-data -w
+# NAME       STATUS   VOLUME      CAPACITY   ACCESS MODES   STORAGECLASS
+# app-data   Bound    pvc-xxxxx   10Gi       RWO            rawfile-localpv
+# app-data   Bound    pvc-xxxxx   20Gi       RWO            rawfile-localpv
+```
+
+Check events and conditions if it takes longer than expected:
+
+```bash
+kubectl describe pvc app-data
+```
+
+Under the hood, the `csi-resizer` sidecar calls the controller, which forwards the request to the node that owns the volume. The node grows the backing file, resizes the loop device, and expands the filesystem online.
+
+## Verify Inside the Pod
+
+```bash
+kubectl exec app -- df -hT /data
+# Filesystem     Type  Size  Used Avail Use% Mounted on
+# /dev/loop3     ext4   20G  1.1G   18G   6% /data
+```
+
+No pod restart is needed - the new capacity is visible immediately after the resize completes.
+
+## Block Mode Volumes
+
+Block volumes (`volumeMode: Block`) are also expandable. If the volume is currently unstaged (no pod consuming it), only the backing file is grown; node-side expansion is deferred until the volume is next attached. The application inside the pod is responsible for recognizing the larger device.
+
+## Limitations
+
+| Item | Status |
+|---|---|
+| Online expansion (ext4/xfs/btrfs) while pod is running | Supported |
+| Shrinking | Not supported - requests to reduce size are rejected by Kubernetes |
+| Expansion beyond pool free space | Fails with `Not enough disk space` |
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| PVC capacity never updates | Check: `allowVolumeExpansion: true` on StorageClass, `capabilities.resize.enabled=true` in chart, controller deployment is running: `kubectl -n openebs logs deploy/<release>-controller`. |
+| `Not enough disk space` | The pool on the volume's node lacks free capacity. Free space or grow the underlying disk. Monitor: `rawfile_pool_remaining_capacity_bytes`. |
+| `Resizing capabilities are disabled` | Set `capabilities.resize.enabled=true` and upgrade the Helm release. |
+| Filesystem size unchanged but PV shows new size | Node-side expansion pending - ensure the node plugin is healthy; kubelet triggers `NodeExpandVolume` on the mounted node. |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [StorageClass Parameters](../configuration/rawfile-storageclass-parameters.md)
+- [Monitoring](rawfile-monitoring.md)
+- [Storage Pools](rawfile-storage-pools.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-snapshot.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-snapshot.md
@@ -1,0 +1,168 @@
+---
+id: rawfile-snapshot
+title: Snapshots
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Snapshots
+ - VolumeSnapshot
+description: This document explains how to create, use, and delete volume snapshots with Local PV Rawfile.
+---
+
+Local PV Rawfile supports block-level volume snapshots using the standard Kubernetes `VolumeSnapshot` API. Snapshots are node-local and processed as persistent background tasks with automatic retry across driver restarts.
+
+## Requirements
+
+- Snapshots must be enabled in the chart (default): `capabilities.snapshots.enabled=true`
+- Kubernetes VolumeSnapshot CRDs must be installed in the cluster
+- A `VolumeSnapshotClass` must exist for the rawfile driver
+
+## Create a VolumeSnapshotClass
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: rawfile-snapshotclass
+driver: rawfile.csi.openebs.io
+deletionPolicy: Delete
+```
+
+Apply:
+
+```bash
+kubectl apply -f snapshotclass.yaml
+```
+
+`deletionPolicy: Delete` removes snapshot data when the `VolumeSnapshot` object is deleted. Use `Retain` to preserve the data after object deletion.
+
+## Create a Snapshot
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: app-data-snap
+spec:
+  volumeSnapshotClassName: rawfile-snapshotclass
+  source:
+    persistentVolumeClaimName: rawfile-pvc
+```
+
+```bash
+kubectl apply -f snapshot.yaml
+kubectl get volumesnapshot app-data-snap -w
+```
+
+The snapshot is `ReadyToUse: true` when complete. The snapshot operation runs as a persistent background task on the node that hosts the volume - it survives driver restarts and retries automatically.
+
+## Snapshot Consistency
+
+Two approaches are available for snapshotting active volumes:
+
+### CoW-Capable Pools (Recommended)
+
+Storage pools backed by filesystems which support reflink (i.e. btrfs or XFS) produce space-efficient, nearly instant snapshots. No freeze is required.
+
+### freezeFs
+
+For pools without CoW support, add `freezeFs: "true"` to the StorageClass. The filesystem is frozen and the entire volume is copied to a new file before it is unfrozen:
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  freezeFs: "true"
+```
+
+:::warning
+With `freezeFs: "true"` on a non-CoW pool, the volume's filesystem stays frozen for the entire snapshot duration. All writes to the volume block until the snapshot completes. For large volumes this can take significant time. Prefer a CoW-capable pool filesystem where possible.
+:::
+
+## Restore a Snapshot to a New PVC
+
+Specify the snapshot as a `dataSource` in a new PVC:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data-restored
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  dataSource:
+    name: app-data-snap
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+```bash
+kubectl apply -f restore.yaml
+```
+
+:::note
+Snapshots are node-local. The restored PVC will be provisioned on the same node that holds the snapshot data.
+:::
+
+## Roll Back an Application
+
+A common pattern for rolling back to a previous state:
+
+1. Scale down the workload to release the PVC:
+   ```bash
+   kubectl scale deployment my-app --replicas=0
+   ```
+
+2. Create a restored PVC from the snapshot (see above).
+
+3. Update the Deployment to reference the restored PVC:
+   ```bash
+   kubectl patch deployment my-app \
+     -p '{"spec":{"template":{"spec":{"volumes":[{"name":"data","persistentVolumeClaim":{"claimName":"app-data-restored"}}]}}}}'
+   ```
+
+4. Scale the workload back up:
+   ```bash
+   kubectl scale deployment my-app --replicas=1
+   ```
+
+## Delete a Snapshot
+
+```bash
+kubectl delete volumesnapshot app-data-snap
+```
+
+With `deletionPolicy: Delete`, the snapshot data on the node is removed. With `Retain`, the backing data remains.
+
+:::important
+Delete all VolumeSnapshots before deleting the PVC or uninstalling the driver to avoid leaked data on nodes.
+:::
+
+## Capacity Considerations
+
+- CoW-capable pools (filesystems with reflink enabled): snapshots consume only the changed blocks after the snapshot point.
+- Non-CoW pools: each snapshot is a full copy of the volume and consumes the same amount of space as the original.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Snapshot stuck in `Pending` | Check the node plugin logs: `kubectl -n openebs logs ds/<release>-node -c csi-driver`. Snapshot operations are retried on restart. |
+| `Snapshotting capabilities are disabled` | Set `capabilities.snapshots.enabled=true` and upgrade the Helm release. |
+| No VolumeSnapshotClass found | Create a `VolumeSnapshotClass` with `driver: rawfile.csi.openebs.io`. |
+| `Insufficient disk space` | Non-CoW snapshot requires a full copy - check pool free capacity: `rawfile_pool_remaining_capacity_bytes`. |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Create StorageClass(s)](../configuration/rawfile-create-storageclass.md)
+- [Volume Restore (Cloning)](rawfile-volume-restore.md)
+- [Storage Pools](rawfile-storage-pools.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools.md
@@ -1,0 +1,141 @@
+---
+id: rawfile-storage-pools
+title: Storage Pools
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Storage Pools
+description: This document explains how to configure and use storage pools with Local PV Rawfile to enable storage tiering across multiple named storage locations per node.
+---
+
+Storage pools let each node offer one or more named storage locations (for example, an NVMe pool and an HDD pool), each backed by its own filesystem with independent capacity reservations. This enables storage tiering - workloads select a tier by referencing the pool name in the StorageClass.
+
+## Configure Storage Pools
+
+Pools are defined in the Helm chart values under `node.storagePools`. A `node.defaultPool` is required and must reference one of the defined pools.
+
+```yaml
+node:
+  defaultPool: hdd
+  storagePools:
+    hdd:
+      path: /var/local/openebs/rawfile/hdd/
+      reservedCapacity: "10%"
+      reservedCapacityMode: plain
+    nvme:
+      path: /mnt/nvme/rawfile/
+      reservedCapacity: 20GiB
+      reservedCapacityMode: subtract-from-total
+```
+
+Apply the updated values:
+
+```bash
+helm upgrade rawfile-localpv rawfile-localpv/rawfile-localpv -n openebs -f values.yaml
+```
+
+## Pool Naming Rules
+
+Pool names must be DNS-compatible:
+- Length: 3–63 characters
+- Characters: letters (uppercase or lowercase), digits, and hyphens only
+- Cannot start or end with a hyphen
+
+## Reserved Capacity Modes
+
+Each pool defines how much disk space is reserved for non-pool use.
+
+| Mode | Behavior |
+|---|---|
+| `plain` | The pool grows until the specified capacity remains free on the backing filesystem. Suitable for shared disks. |
+| `subtract-from-total` | The pool is capped at `total disk size − reserved amount`. Suitable for dedicated disks. |
+
+**`plain` example:** A 1 TB disk with `reservedCapacity: "10%"` allows the pool to use up to 900 GB.
+
+**`subtract-from-total` example:** A 1 TB disk with `reservedCapacity: 20GiB` caps the pool at 980 GB regardless of other filesystem usage.
+
+## Validation Rules
+
+The driver validates pool configuration on startup:
+
+- Pool paths must exist or be creatable on each node.
+- Each pool must be on a distinct backing filesystem - multiple pools cannot share the same device.
+- The `defaultPool` must reference an existing pool entry.
+- Pool paths must be unique per node.
+
+## Copy-on-Write (CoW) Capable Pools
+
+Snapshots and clones are always available, but pools backed by CoW-capable filesystems make them fast and space-efficient (reflinks, nearly instant). Pools without CoW support perform a full data copy.
+
+| Filesystem | CoW Support |
+|---|---|
+| btrfs | Native |
+| XFS | With `mkfs.xfs -m reflink=1` |
+| ext4 | No reflink support (full copy) |
+
+To create an XFS pool with reflink enabled:
+
+```bash
+mkfs.xfs -m reflink=1 /dev/sdb
+mount /dev/sdb /mnt/nvme/rawfile/
+```
+
+## Create StorageClasses per Pool
+
+Create a separate StorageClass for each pool tier and reference the pool by name via the `storagePool` parameter:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-nvme
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  storagePool: nvme
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-hdd
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  storagePool: hdd
+```
+
+:::important
+`volumeBindingMode: WaitForFirstConsumer` is required. Using `Immediate` will fail with "No preferred topology set" because the driver needs to know which node the pod will land on to select the correct pool.
+:::
+
+A StorageClass without a `storagePool` parameter uses `node.defaultPool`.
+
+## Monitor Pool Capacity
+
+Pool metrics are exposed on port 9100. Use these PromQL queries to track capacity:
+
+```promql
+# Remaining capacity per pool
+rawfile_pool_remaining_capacity_bytes
+
+# Alert when a pool has less than 10 GiB free
+rawfile_pool_remaining_capacity_bytes < 10 * 1024^3
+```
+
+See [Monitoring](rawfile-monitoring.md) for the full metrics reference.
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Create StorageClass(s)](../configuration/rawfile-create-storageclass.md)
+- [StorageClass Parameters](../configuration/rawfile-storageclass-parameters.md)
+- [Monitoring](rawfile-monitoring.md)
+- [Snapshots](rawfile-snapshot.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-thin-provisioning.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-thin-provisioning.md
@@ -1,0 +1,102 @@
+---
+id: rawfile-thin-provisioning
+title: Thin Provisioning
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Thin Provisioning
+ - Overprovisioning
+description: This document explains thin provisioning with Local PV Rawfile, enabling overprovisioned volumes using sparse files.
+---
+
+By default, Local PV Rawfile creates **thick-provisioned** volumes - the backing file is fully pre-allocated at creation time. Thin provisioning uses sparse files instead, so only the blocks actually written by the application consume physical disk space.
+
+## Thick vs Thin Provisioning
+
+| Feature | Thick (default) | Thin |
+|---|---|---|
+| Backing file | Pre-allocated | Sparse (holes represent unwritten blocks) |
+| Disk usage at creation | Equal to requested size | Near zero |
+| Overprovisioning | Not possible | Possible |
+| Performance | Predictable - no allocation latency | May have small latency on first write to a block |
+| Risk | None - space is reserved | Out-of-space if physical disk fills before logical limit |
+
+## Enable Thin Provisioning
+
+Set `thinProvision: "true"` in the StorageClass parameters:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-thin
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  thinProvision: "true"
+```
+
+All PVCs created from this StorageClass will use sparse files.
+
+## Overprovisioning
+
+Thin provisioning enables you to provision more logical capacity than physical disk space. For example, on a 100 GB pool you could provision ten 20 GB volumes (200 GB logical), as long as the total data written across all volumes does not exceed the physical pool capacity.
+
+Monitor the overcommit ratio:
+
+```promql
+rawfile_pool_volumes_logical_bytes / rawfile_pool_capacity_bytes
+```
+
+:::warning
+If the underlying pool runs out of physical space, writes to thin-provisioned volumes will fail with I/O errors at the application level. Monitor `rawfile_pool_remaining_capacity_bytes` and set alerts before this occurs.
+:::
+
+## Monitor Physical vs Logical Usage
+
+```promql
+# Physical bytes actually written across all volumes in a pool
+rawfile_pool_volumes_physical_bytes
+
+# Logical (provisioned) bytes across all volumes
+rawfile_pool_volumes_logical_bytes
+
+# Space savings ratio (higher = more savings from thin provisioning or CoW)
+1 - (rawfile_pool_volumes_physical_bytes / rawfile_pool_volumes_logical_bytes)
+```
+
+Per-volume physical usage:
+
+```promql
+rawfile_volume_physical_bytes
+```
+
+## Thin Provisioning with CoW Pools
+
+Thin provisioning combines well with Copy-on-Write pools (filesystems with reflink enabled):
+
+- New volumes start near-empty (sparse file).
+- Snapshots and clones only consume the blocks that differ from their source.
+- Physical usage tracks actual data written, not logical size.
+
+## Thick Provisioning Use Cases
+
+Use thick provisioning (the default) when:
+
+- Predictable I/O performance is critical.
+- You need a guaranteed reservation of disk space for a workload.
+- The pool is shared with other services and you want to avoid unexpected out-of-space conditions.
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [StorageClass Parameters](../configuration/rawfile-storageclass-parameters.md)
+- [Monitoring](rawfile-monitoring.md)
+- [Storage Pools](rawfile-storage-pools.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-volume-restore.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-volume-restore.md
@@ -1,0 +1,153 @@
+---
+id: rawfile-volume-restore
+title: Volume Restore (Cloning)
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Advanced Operations
+ - Volume Restore
+ - Clone
+ - PVC Clone
+description: This document explains how to clone an existing PVC or restore a snapshot into a new PVC with Local PV Rawfile.
+---
+
+Local PV Rawfile supports two ways to create a new PVC from existing data:
+
+- **PVC Clone** - creates an independent copy of a PVC without an intermediate snapshot object.
+- **Snapshot Restore** - creates a new PVC from an existing `VolumeSnapshot`.
+
+Both are node-local: the new PVC is provisioned on the same node as the source.
+
+## PVC Clone
+
+Cloning creates a new PVC that starts as an exact copy of an existing PVC. No `VolumeSnapshot` object is created.
+
+### Requirements
+
+- Snapshots must be enabled in the chart (used internally for clone): `capabilities.snapshots.enabled=true`
+- The source pool must have roughly **3× the volume size** of free capacity while the clone is being materialized.
+- Cross-node cloning is not yet supported - source and clone must land on the same node.
+
+### Create a Clone
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data-clone
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: app-data
+  resources:
+    requests:
+      storage: 10Gi    # must be >= source size
+```
+
+```bash
+kubectl apply -f clone.yaml
+```
+
+### Consume the Clone
+
+The clone, like any rawfile PVC, is provisioned when a pod uses it (`WaitForFirstConsumer`):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-clone-consumer
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep infinity"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: app-data-clone
+```
+
+```bash
+kubectl get pvc app-data-clone -w    # wait for Bound
+kubectl exec app-clone-consumer -- ls /data
+```
+
+The clone is fully independent after creation - changes to the clone do not affect the source, and changes to the source do not affect the clone.
+
+### Clone Consistency
+
+Cloning an actively-written volume produces a crash-consistent copy at best. For consistent clones:
+
+- Use a StorageClass with `freezeFs: "true"` - the filesystem is frozen during the copy.
+- Use a CoW-capable pool (XFS with reflink, btrfs) - the copy is nearly instantaneous and consistent.
+
+:::warning
+With `freezeFs: "true"` on a **non-CoW** pool, the filesystem stays frozen for the **entire duration of the copy**. All writes to the volume block until the clone completes, which can take a long time for large volumes. Prefer a CoW-capable pool.
+:::
+
+If neither `freezeFs` nor a CoW pool is available and the volume is actively written, the clone request will be rejected. Scale the workload down first.
+
+## Snapshot Restore
+
+Restore a previously taken snapshot into a new PVC by specifying it as a `dataSource`.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data-restored
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  dataSource:
+    name: app-data-snap
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+```bash
+kubectl apply -f restore.yaml
+kubectl get pvc app-data-restored -w
+```
+
+The restored PVC will land on the same node that holds the snapshot data.
+
+## Clone vs. Snapshot Restore
+
+| Feature | PVC Clone | Snapshot Restore |
+|---|---|---|
+| Point-in-time copy kept around | No - one-shot copy | Yes - snapshot object persists |
+| Extra API objects needed | None | `VolumeSnapshot` + `VolumeSnapshotClass` |
+| Use case | Duplicate an environment, fork test data | Backup/rollback points, repeated restores |
+
+Both use the same underlying copy mechanism: cheap on CoW-capable pools, full copy otherwise.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Insufficient disk space (Cloning a volume requires at least 3× the volume size)` | Free capacity on the source node's pool, or grow the underlying disk. |
+| Clone PVC stuck in `Pending` | Needs a consuming pod (`WaitForFirstConsumer`). Check `kubectl describe pvc` events. |
+| `Snapshotting capabilities are disabled` | Enable `capabilities.snapshots.enabled=true` and upgrade the Helm release. |
+| Clone must land on a different node | Not yet supported - cross-node cloning is in progress. |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Snapshots](rawfile-snapshot.md)
+- [Storage Pools](rawfile-storage-pools.md)
+- [Create PVC](../configuration/rawfile-create-pvc.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-pvc.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-pvc.md
@@ -1,0 +1,180 @@
+---
+id: rawfile-create-pvc
+title: Create PersistentVolumeClaim
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Configuration
+ - Create PVC
+ - Create PersistentVolumeClaim
+description: This document provides step-by-step instructions to create a PersistentVolumeClaim (PVC) using the Local PV Rawfile storage class.
+---
+
+# Create PersistentVolumeClaim
+
+This document provides step-by-step instructions to create a PersistentVolumeClaim (PVC) using the Local PV Rawfile storage class. It covers filesystem mode and block mode PVCs, how to verify binding, how to consume the volume in a pod, and how to delete volumes.
+
+Before you begin, make sure:
+
+- The Rawfile driver is installed and running. Refer to the [Installation](../../../../quickstart-guide/installation.md) documentation for more information.
+- A StorageClass exists. The Helm chart creates one named `rawfile-localpv` by default:
+
+  ```bash
+  kubectl get sc rawfile-localpv
+  ```
+
+## Create a Filesystem Mode PVC
+
+This is the default volume mode. The driver formats the backing file with the filesystem specified in the StorageClass and mounts it as a directory inside the pod.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rawfile-pvc
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+Apply the PVC:
+
+```bash
+kubectl apply -f pvc.yaml
+```
+
+The PVC will remain in `Pending` state until a pod that uses it is scheduled. This is expected behavior with `volumeBindingMode: WaitForFirstConsumer`.
+
+```bash
+kubectl get pvc rawfile-pvc
+```
+
+## Create a Block Mode PVC
+
+For workloads that manage their own storage format (e.g. databases), use `volumeMode: Block`. The driver exposes the loop device directly to the pod without formatting.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rawfile-block-pvc
+spec:
+  storageClassName: rawfile-localpv
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+:::note
+`fsType`, `formatOptions`, and `mountOptions` StorageClass parameters are ignored for block mode PVCs. The `readOnly` attribute on block PVCs is not currently honored.
+:::
+
+## Consume the Volume in a Pod
+
+### Filesystem Mode
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep infinity"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rawfile-pvc
+```
+
+Once the pod is scheduled, the driver provisions the volume on that node and the PVC transitions to `Bound`:
+
+```bash
+kubectl get pvc rawfile-pvc
+```
+
+Verify the volume inside the pod:
+
+```bash
+kubectl exec app -- df -hT /data
+```
+
+### Block Mode
+
+Use `volumeDevices` instead of `volumeMounts` to consume a block PVC:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-block
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep infinity"]
+      volumeDevices:
+        - name: data
+          devicePath: /dev/xvda
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rawfile-block-pvc
+```
+
+## PVC Parameters Reference
+
+| Parameter | Required | Values | Notes |
+|---|---|---|---|
+| `storageClassName` | Yes | Rawfile StorageClass name | Must reference a StorageClass with `rawfile.csi.openebs.io` provisioner |
+| `accessModes` | Yes | `ReadWriteOnce` | Only `ReadWriteOnce` is supported |
+| `resources.requests.storage` | Yes | e.g. `10Gi`, `100Gi` | Provisioning fails if the pool lacks sufficient free capacity |
+| `volumeMode` | No | `Filesystem` (default) / `Block` | `Block` exposes a raw loop device; formatting is skipped |
+| `dataSource` (VolumeSnapshot) | No | VolumeSnapshot reference | Restores a snapshot into a new PVC — see [Snapshots](../advanced-operations/rawfile-snapshot.md) |
+| `dataSource` (PVC clone) | No | PVC reference | Clones an existing PVC — see [Volume Restore](../advanced-operations/rawfile-volume-restore.md) |
+
+## Deprovisioning
+
+Delete the workload using the PVC first, then delete the PVC:
+
+```bash
+kubectl delete pod app
+kubectl delete pvc rawfile-pvc
+```
+
+With `reclaimPolicy: Delete` (default), the PV, backing file, and metadata are removed from the node. With `Retain`, the PV and data remain until you delete the PV manually.
+
+:::important
+Delete any VolumeSnapshots of a volume before deleting the volume itself if you intend to fully reclaim space.
+:::
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| PVC `Pending` forever | Is a pod consuming it? Check pool capacity: `kubectl get csistoragecapacities -A`. Check events: `kubectl describe pvc <name>`. |
+| `Invalid storage pool` error | The `storagePool` parameter in the StorageClass does not match a configured pool on the node. |
+| Pod stuck in `ContainerCreating` | Check node plugin logs: `kubectl -n openebs logs ds/<release>-node -c csi-driver`. |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../../quickstart-guide/installation.md)
+- [Create StorageClass(s)](rawfile-create-storageclass.md)
+- [StorageClass Parameters](rawfile-storageclass-parameters.md)
+- [Deploy an Application](rawfile-deployment.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-storageclass.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-storageclass.md
@@ -1,0 +1,230 @@
+﻿---
+id: rawfile-create-storageclass
+title: Create StorageClass(s)
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Configuration
+ - Create StorageClass
+ - Create Local PV Rawfile StorageClass(s)
+description: This guide will help you to create Local PV Rawfile StorageClass.
+---
+
+# Create StorageClass(s)
+
+This document provides step-by-step instructions on creating a StorageClass for Local PV Rawfile, with examples covering different filesystem types, thin provisioning, and volume binding modes.
+
+The provisioner name for Local PV Rawfile is `rawfile.csi.openebs.io`. This must be set in every StorageClass so that provisioning requests are handled by the Rawfile driver.
+
+:::important
+Always set `volumeBindingMode: WaitForFirstConsumer`. The driver provisions volumes on the node chosen by the Kubernetes scheduler and requires that topology information. Using `Immediate` will cause provisioning to fail with "No preferred topology set".
+:::
+
+## Default StorageClass (ext4)
+
+The following is a basic StorageClass that provisions volumes formatted with ext4, which is the default filesystem:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-ext4
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+```
+
+## StorageClass with XFS
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-xfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "xfs"
+```
+
+## StorageClass with Btrfs
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-btrfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "btrfs"
+```
+
+## StorageClass with Thin Provisioning
+
+By default, volumes are **thick-provisioned** - the full backing file is pre-allocated at creation time. Thin provisioning creates a sparse backing file instead, meaning disk space is allocated on demand as data is written. This enables overprovisioning, so you must monitor actual pool usage (`rawfile_pool_remaining_capacity_bytes`) to avoid the backing filesystem running out of space.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-thin
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+  thinProvision: "true"
+  formatOptions: "-E nodiscard"
+```
+
+:::note
+For ext4 volumes, 5% of the capacity is reserved for the root user by default. To remove this reservation and make the full capacity available to applications, add `-m 0` to `formatOptions`:
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+  formatOptions: "-m 0"
+```
+:::
+
+## StorageClass with Snapshots Enabled (Copy-on-Write)
+
+To enable block-level snapshots using copy-on-write (reflink), set `copyOnWrite` to `"true"`. The underlying storage pool's filesystem must support reflinks. CoW support varies by filesystem:
+
+| Filesystem | CoW Support | Setup Required |
+|---|---|---|
+| btrfs | Native | None - works out of the box |
+| XFS | With reflink | Format the pool device with `mkfs.xfs -m reflink=1` |
+| ext4 | Not supported | Full data copy is used instead |
+
+**For btrfs** - no extra setup needed, just set `fstype: btrfs`:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-cow-btrfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "btrfs"
+  copyOnWrite: "true"
+```
+
+**For XFS**, format the pool device with reflink enabled on each node, then configure the pool path in Helm values:
+
+```bash
+mkfs.xfs -m reflink=1 /dev/sdb
+mount /dev/sdb /mnt/nvme/rawfile/
+```
+
+Create a StorageClass targeting that pool:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-cow-xfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "xfs"
+  copyOnWrite: "true"
+  storagePool: "nvme"
+```
+
+See [Storage Pools](../advanced-operations/rawfile-storage-pools.md) for how to configure the pool in Helm values.
+
+## StorageClass with FreezeFS for In-Use Snapshots
+
+For volumes that need to be snapshotted while in use and where CoW is not available, enable `freezeFs`. This briefly freezes the filesystem during snapshot creation to ensure consistency.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-freezefs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+  freezeFs: "true"
+```
+
+## StorageClass Targeting a Specific Storage Pool
+
+Storage pools must be configured in the Helm chart before they can be referenced in a StorageClass. See [Storage Pools](../advanced-operations/rawfile-storage-pools.md) for how to define named pools with independent paths and capacity reservations.
+
+Once pools are configured, use the `storagePool` parameter to pin volumes to a named pool:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-fast-pool
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: "ext4"
+  storagePool: "fast-pool"
+```
+
+:::note
+To use the node's default pool, omit the `storagePool` key entirely. Setting it to an empty string (`""`) is rejected as an invalid pool name.
+:::
+
+## VolumeSnapshotClass
+
+To use snapshots with Local PV Rawfile, a `VolumeSnapshotClass` is required. The Helm chart creates one named `rawfile-localpv` by default. To create one manually:
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: rawfile-localpv
+driver: rawfile.csi.openebs.io
+deletionPolicy: Delete
+```
+
+There are no driver-specific parameters on the `VolumeSnapshotClass`. Snapshot behavior (`freezeFs`, `copyOnWrite`) is controlled by the volume's StorageClass.
+
+## StorageClass Parameters Conformance Matrix
+
+### Standard StorageClass Parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `allowVolumeExpansion` | `true` / `false` | Set to `true` to enable online volume resize |
+| `volumeBindingMode` | `WaitForFirstConsumer` | **Required.** `Immediate` causes provisioning to fail |
+| `reclaimPolicy` | `Retain` / `Delete` | `Delete` removes the backing file when the PV is released |
+
+### Rawfile-Specific StorageClass Parameters
+
+| Parameter | Values | Description |
+|---|---|---|
+| `csi.storage.k8s.io/fstype` | `ext4` (default), `xfs`, `btrfs` | Filesystem used to format the volume; ignored for `volumeMode: Block` |
+| `thinProvision` | `"true"` / `"false"` (default) | `"true"` creates a sparse backing file; enables overprovisioning - monitor pool usage |
+| `copyOnWrite` | `"true"` / `"false"` / unset | CoW reflink attribute on the backing file; leave unset to autodetect per pool |
+| `freezeFs` | `"true"` / `"false"` (default) | Briefly freezes the filesystem during snapshots of in-use volumes for consistency |
+| `formatOptions` | Extra `mkfs` flags (e.g. `"-m 0"`, `"-i maxpct=10"`) | Applied once at volume creation time only |
+| `mountOptions` | Mount flags (e.g. `noatime`) | Passed to `mount` when attaching the volume to a pod |
+| `storagePool` | Pool name string | Targets a named storage pool; omit the key entirely for the node's default pool |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../../quickstart-guide/installation.md)
+- [StorageClass Parameters](rawfile-storageclass-parameters.md)
+- [Create PVC](rawfile-create-pvc.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment.md
@@ -1,0 +1,71 @@
+﻿---
+id: rawfile-deployment
+title: Deploy an Application
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Configuration
+ - Deploy an Application
+description: This section explains the instructions to deploy an application for the OpenEBS Local Persistent Volumes (PV) backed by Local PV Rawfile storage.
+---
+
+This document explains the instructions to deploy an application for the OpenEBS Local Persistent Volumes (PV) backed by Local PV Rawfile storage.
+
+Create the deployment using the PVC backed by Local PV Rawfile storage.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "while true; do sleep 60; done"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rawfile-pvc
+```
+
+After the deployment of the application, the node will attach the loop device, format it with the configured filesystem, and mount it into the pod. You can verify the volume is in use:
+
+```bash
+kubectl get pvc rawfile-pvc
+kubectl exec app -- df -hT /data
+```
+
+**Sample Output**
+
+```
+Filesystem     Type  Size  Used Avail Use% Mounted on
+/dev/loop3     ext4   10G   24K  9.5G   1% /data
+```
+
+## PersistentVolumeClaim Conformance Matrix
+
+The following matrix shows the supported PersistentVolumeClaim parameters for Local PV Rawfile.
+
+| Parameter | Values |
+|---|---|
+| `accessModes` | Supported: `ReadWriteOnce` / Not Supported: `ReadWriteMany`, `ReadOnlyMany` |
+| `storageClassName` | StorageClass name |
+| `resources.requests.storage` | Storage size with unit (e.g. `10Gi`, `100Gi`) |
+| `volumeMode` | `Filesystem` (default), `Block` |
+| `dataSource` (VolumeSnapshot) | Supported - restores a snapshot into a new PVC |
+| `dataSource` (PVC clone) | Supported - clones an existing same-node PVC |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../../quickstart-guide/installation.md)
+- [Create StorageClass(s)](rawfile-create-storageclass.md)
+- [StorageClass Parameters](rawfile-storageclass-parameters.md)
+- [Create PVC](rawfile-create-pvc.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-storageclass-parameters.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-storageclass-parameters.md
@@ -1,0 +1,213 @@
+---
+id: rawfile-storageclass-parameters
+title: StorageClass Parameters
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile
+ - Configuration
+ - StorageClass Parameters
+ - StorageClass Options
+description: This guide describes all supported StorageClass parameters for Local PV Rawfile.
+---
+
+# StorageClass Parameters
+
+This document describes all supported StorageClass parameters for Local PV Rawfile and explains how to configure them. These parameters control filesystem selection, provisioning behavior, snapshot support, mount options, and storage pool targeting.
+
+## fstype (Optional)
+
+Specifies the filesystem used to format the volume. If unspecified, falls back to the node plugin's `defaultFs` (chart value `node.defaultFs`, default `ext4`). Ignored for `volumeMode: Block` PVCs.
+
+Supported values: `ext4` (default), `xfs`, `btrfs`.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-xfs
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+```
+
+:::note
+Parameter keys are matched case-insensitively by the driver. Values must be strings - quote booleans (e.g. `"true"`, `"false"`).
+:::
+
+## thinProvision (Optional)
+
+Controls whether the backing file is pre-allocated (thick) or sparse (thin).
+
+- **`"false"` (default)** - Thick provisioning. The full backing file is allocated at volume creation time. Space is consumed from the pool upfront and overprovisioning is not possible.
+- **`"true"`** - Thin provisioning. A sparse backing file is created and disk space is allocated on write. This enables overprovisioning, so you must monitor real pool usage (`rawfile_pool_remaining_capacity_bytes`) to avoid running the backing filesystem out of space.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-thin
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  thinProvision: "true"
+```
+
+## formatOptions (Optional)
+
+Extra flags passed to `mkfs.<fstype>` when the volume is formatted at creation time. Applied only once at first format - not on subsequent mounts.
+
+Examples:
+- ext4: `"-m 0"` removes the 5% root-reserved block reservation, making the full capacity available to applications.
+- xfs: `"-i maxpct=10"` limits inode space.
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  formatOptions: "-m 0"
+```
+
+:::note
+In Helm chart values, `formatOptions` is a list that is joined with spaces at runtime:
+```yaml
+storageClasses:
+  - name: rawfile-localpv
+    formatOptions: ["-m", "0"]
+```
+:::
+
+## copyOnWrite (Optional)
+
+Controls the copy-on-write (reflink) attribute on the volume's backing file.
+
+- **Unset (recommended)** - The driver autodetects CoW support on each pool's backing filesystem and applies it accordingly.
+- **`"true"`** - Explicitly enable CoW. The pool's backing filesystem must support reflinks (btrfs natively, or XFS created with `mkfs.xfs -m reflink=1`).
+- **`"false"`** - Explicitly disable CoW. Useful for database workloads where `nodatacow` improves write performance.
+
+When CoW is enabled, snapshots and clones are cheap (reflink copy). Without CoW, snapshots perform a full data copy.
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  copyOnWrite: "true"
+```
+
+## freezeFs (Optional)
+
+- **`"false"` (default)** - No filesystem freeze during snapshot.
+- **`"true"`** - The volume's filesystem is briefly frozen (`fsfreeze`) while a snapshot of an in-use volume is taken, producing a crash-consistent image.
+
+Use this when the pool's backing filesystem does not support CoW and you need consistent snapshots of running volumes. Expect a brief I/O pause on the volume during snapshot creation.
+
+:::important
+On a non-CoW pool with `freezeFs: "true"`, the filesystem stays frozen for the **entire duration of the data copy**. For large volumes this can be significant. Prefer a CoW-capable pool filesystem where possible.
+:::
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  copyOnWrite: "false"
+  freezeFs: "true"
+```
+
+## mountOptions (Optional)
+
+Mount flags passed to the `mount` command when the volume is attached to a pod. If unspecified, `-o default` is used.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rawfile-noatime
+provisioner: rawfile.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+mountOptions:
+  - noatime
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+```
+
+:::note
+Mount options are not validated by the driver. If mount options are invalid, the volume mount will fail.
+:::
+
+## storagePool (Optional)
+
+Targets a specific named storage pool on the node. If omitted, the node's `defaultPool` is used.
+
+```yaml
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  storagePool: nvme
+```
+
+:::important
+Omit the `storagePool` key entirely to use the default pool. Setting it to an empty string (`""`) is rejected as an invalid pool name.
+:::
+
+Provisioning fails with `INVALID_ARGUMENT` if the named pool does not exist on the selected node.
+
+## volumeBindingMode (Required)
+
+:::important
+Always use `WaitForFirstConsumer`. The driver requires the node topology set by the Kubernetes scheduler to provision a volume. Using `Immediate` fails with "No preferred topology set".
+:::
+
+| Value | Behavior |
+|---|---|
+| `WaitForFirstConsumer` | Volume is provisioned when a pod using the PVC is scheduled - node is chosen by the scheduler |
+| `Immediate` | Not supported - provisioning fails |
+
+## allowVolumeExpansion (Optional)
+
+Set to `true` to enable online volume expansion. Requires `capabilities.resize.enabled=true` in the Helm chart (default). Supported for ext4, xfs, and btrfs. Shrinking is not supported.
+
+```yaml
+allowVolumeExpansion: true
+```
+
+## reclaimPolicy (Optional)
+
+Controls what happens to the backing file and PV when the PVC is deleted.
+
+| Value | Behavior |
+|---|---|
+| `Delete` (default) | The PV and its backing file are deleted when the PVC is released |
+| `Retain` | The PV and backing file are kept until manually deleted |
+
+## StorageClass Parameters Conformance Matrix
+
+### Standard Parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `volumeBindingMode` | `WaitForFirstConsumer` | **Required.** `Immediate` causes provisioning to fail |
+| `allowVolumeExpansion` | `true` / `false` | Enable online resize |
+| `reclaimPolicy` | `Delete` (default) / `Retain` | Backing file lifecycle on PVC deletion |
+| `mountOptions` | Mount flags | Not validated - invalid options cause mount failure |
+
+### Rawfile-Specific Parameters
+
+| Parameter | Default | Values | Description |
+|---|---|---|---|
+| `csi.storage.k8s.io/fstype` | `ext4` | `ext4`, `xfs`, `btrfs` | Volume filesystem type |
+| `thinProvision` | `"false"` | `"true"` / `"false"` | Sparse vs pre-allocated backing file |
+| `formatOptions` | - | `mkfs` flags string | Applied once at volume creation |
+| `copyOnWrite` | autodetect | `"true"` / `"false"` / unset | CoW attribute on backing file |
+| `freezeFs` | `"false"` | `"true"` / `"false"` | Freeze filesystem during in-use snapshots |
+| `storagePool` | node default | Pool name string | Target a named storage pool |
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../../quickstart-guide/installation.md)
+- [Create StorageClass(s)](rawfile-create-storageclass.md)
+- [Create PVC](rawfile-create-pvc.md)
+- [Storage Pools](../advanced-operations/rawfile-storage-pools.md)

--- a/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview.md
+++ b/docs/versioned_docs/version-4.5.x/user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview.md
@@ -1,0 +1,44 @@
+---
+id: rawfile-overview
+title: Local PV Rawfile Overview
+keywords:
+ - OpenEBS Local PV Rawfile
+ - Local PV Rawfile Overview
+ - Installation
+ - Prerequisites
+description: This section explains the overview of Local PV Rawfile.
+---
+
+OpenEBS Local PV Rawfile provisions persistent volumes backed by raw files on the host filesystem, exposed to pods as independent block devices via Linux loop devices. Each volume is a thick or thin-provisioned file formatted with its own filesystem (`ext4`, `btrfs`, or `xfs`), making it fully isolated from the host's filesystem. This approach delivers near-baremetal disk performance with hard-enforced capacity limits, real-time volume metrics, and per-volume filesystem customization - addressing the core limitations of HostPath-based provisioning.
+
+## How It Works
+
+When a PVC is created, the driver allocates a raw file in a configured storage pool directory on the selected node and attaches it to a Linux loop device. That loop device is then formatted with the requested filesystem and mounted into the pod. Since each volume is an independent block device, the operating system enforces size limits natively and usage metrics are available in O(1) via `df`.
+
+The driver runs as a DaemonSet node plugin on every eligible node, handling both CSI Node and Controller operations locally. When volume resize is enabled, a separate controller Deployment manages cluster-wide resize requests. Long-running operations such as volume creation and snapshot creation are handled asynchronously by a built-in Task Manager, which persists state so that operations survive driver restarts and are retried automatically on failure.
+
+Volumes are strictly node-local - the Kubernetes scheduler uses storage capacity tracking to place pods only on nodes with sufficient pool space, and once a PV is created its node affinity is permanent.
+
+## Installation
+
+Refer to the [OpenEBS Installation documentation](../../../quickstart-guide/installation.md) to install Local PV Rawfile.
+
+## Advantages
+
+- Near-baremetal disk performance – Direct I/O via loop devices with near-zero overhead.
+- Hard-enforced volume size limits – Capacity is enforced by the OS, not just advisory quotas.
+- Real-time volume usage metrics – Per-volume disk usage readable in O(1) via `df`, with Prometheus metrics exposed per pool and node.
+- Per-volume filesystem customization – Each volume can use a different filesystem (ext4, btrfs, xfs) with independent format and mount options.
+- Dynamic provisioning – Volumes are created on demand without manual pre-allocation.
+- Volume snapshots and cloning – Block-level copy-on-write snapshots and same-node volume cloning (CoW efficiency depends on the underlying pool filesystem — see [Storage Pools](advanced-operations/rawfile-storage-pools.md)).
+- Online volume expansion – Expand volumes without downtime on supported filesystems (ext4, btrfs, xfs).
+- Multiple storage pools per node – Independent pool configuration with reserved capacity management.
+
+## Support
+
+If you encounter issues or have a question, file a [Github issue](https://github.com/openebs/rawfile-localpv/issues/new), or talk to us on the [#openebs channel on the Kubernetes Slack server](https://kubernetes.slack.com/messages/openebs/).
+
+## See Also
+
+- [Installation](../../../quickstart-guide/installation.md)
+- [Deploy an Application](../../../quickstart-guide/deploy-a-test-application.md)

--- a/docs/versioned_sidebars/version-4.5.x-sidebars.json
+++ b/docs/versioned_sidebars/version-4.5.x-sidebars.json
@@ -415,8 +415,112 @@
                     }
                   ]
                 }
-              ] 
-            },   
+              ]
+            },
+            {
+              "collapsed": true,
+              "type": "category",
+              "label": "Local PV Rawfile",
+              "customProps": {
+                "icon": "Book"
+              },
+              "items": [
+                {
+                  "type": "doc",
+                  "id": "user-guides/local-storage-user-guide/local-pv-rawfile/rawfile-overview",
+                  "label": "Overview",
+                  "key": "Rawfile_Overview"
+                },
+                {
+                  "collapsed": true,
+                  "type": "category",
+                  "label": "Configuration",
+                  "key": "Rawfile_Configuration",
+                  "customProps": {
+                    "icon": "Settings"
+                  },
+                  "items": [
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-storageclass",
+                      "label": "Create StorageClass(s)",
+                      "key": "rawfile-create-storageclass"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-storageclass-parameters",
+                      "label": "StorageClass Parameters",
+                      "key": "rawfile-storageclass-parameters"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-create-pvc",
+                      "label": "Create PVC",
+                      "key": "rawfile-create-pvc"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/configuration/rawfile-deployment",
+                      "label": "Deploy an Application",
+                      "key": "rawfile-deployment"
+                    }
+                  ]
+                },
+                {
+                  "collapsed": true,
+                  "type": "category",
+                  "label": "Advanced Operations",
+                  "key": "Rawfile_AdvancedOperations",
+                  "customProps": {
+                    "icon": "Beaker"
+                  },
+                  "items": [
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-storage-pools",
+                      "label": "Storage Pools",
+                      "key": "rawfile-storage-pools"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-snapshot",
+                      "label": "Snapshots",
+                      "key": "rawfile-snapshot"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-volume-restore",
+                      "label": "Volume Restore (Cloning)",
+                      "key": "rawfile-volume-restore"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-resize",
+                      "label": "Volume Resize",
+                      "key": "rawfile-resize"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-monitoring",
+                      "label": "Monitoring",
+                      "key": "rawfile-monitoring"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-raw-block-volume",
+                      "label": "Raw Block Volumes",
+                      "key": "rawfile-raw-block-volume"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "user-guides/local-storage-user-guide/local-pv-rawfile/advanced-operations/rawfile-thin-provisioning",
+                      "label": "Thin Provisioning",
+                      "key": "rawfile-thin-provisioning"
+                    }
+                  ]
+                }
+              ]
+            },
             {
               "collapsed": true,
               "type": "category",


### PR DESCRIPTION
This PR adds full user facing documentation for the Local PV Rawfile storage engine in OpenEBS, following the same structure and style as existing storage docs (Hostpath, LVM, ZFS, Mayastor).

### New Docs - Configuration (4 Docs)
- Overview - Architecture, how loop devices work, DaemonSet/controller/Task Manager internals, advantages
- Create StorageClass(s) - Examples for ext4, xfs, btrfs, thin provisioning, CoW, freezeFs, storage pool targeting, VolumeSnapshotClass, conformance matrix
- StorageClass Parameters - Full per-parameter reference with YAML examples, notes, and warnings
- Create PVC - Filesystem and block mode PVCs, pod consumption, deprovisioning, troubleshooting
- Deploy an Application - Pod YAML using an existing rawfile PVC with verification steps

### New Docs - Advanced Operations (7 Docs)
- Storage Pools - Multi-pool Helm config, naming rules, reserved capacity modes (plain vs subtract-from-total), CoW-capable pools, per-tier StorageClasses
- Snapshots - VolumeSnapshotClass creation, snapshot lifecycle, CoW vs freezeFs consistency, rollback pattern, cleanup order
- Volume Restore (Cloning) - PVC clone, snapshot restore, clone vs snapshot comparison, consistency guarantees
- Volume Resize - Online expansion, allowVolumeExpansion requirement, block mode expansion behavior
- Monitoring - Full Prometheus metrics reference (node/pool/volume level), ServiceMonitor config, PromQL examples
- Raw Block Volumes - Block mode PVC/pod setup, ignored parameters, use cases
- Thin Provisioning - Thick vs thin comparison, sparse file behavior, overprovisioning, monitoring overcommit ratio

### Updated Existing Docs

- Installation - Added note that rawfile is disabled by default; added `--set engines.local.rawfile.enabled=true` install command
- Prerequisites - Added Local PV Rawfile Prerequisites section (loop device support, filesystem tools, storage pool directory)
- Upgrades - Added note that rawfile is a separate Helm release not covered by kubectl openebs upgrade, with separate helm upgrade command
- Uninstallation - Added rawfile uninstall section with required pre-uninstall order (VolumeSnapshots → PVCs → PVs) to avoid leaked loop devices
- Sidebars - Added full Local PV Rawfile navigation tree with Configuration and Advanced Operations categories

Note:
All content sourced from the [rawfile-localpv develop branch docs](https://github.com/openebs/rawfile-localpv/tree/develop/docs)