### PR TITLE
ci: set read permissions only

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   commits_check_job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openebs/website/security/code-scanning/2](https://github.com/openebs/website/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the token is constrained regardless of repository/org defaults.

Best fix for this file: define workflow-level permissions right after the trigger (`on:` block) and before `jobs:`:

- `contents: read`

This is the minimal required scope for `actions/checkout` and lint execution, and it does not change workflow functionality. No new imports, methods, or dependencies are required—only YAML configuration in `.github/workflows/eslint.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
