### PR TITLE
docs: document the OpenEBS 4.6.1 patch release

### DIFF
--- a/docs/main/releases.md
+++ b/docs/main/releases.md
@@ -16,12 +16,12 @@ The status of the various components as of v4.6 are as follows:
 
 | Component Type | Component | Version | Status |
 | :--- | :--- | :--- | :--- |
-| Replicated Storage | Replicated PV Mayastor | 2.12.0 | Stable |
+| Replicated Storage | Replicated PV Mayastor | 2.12.1 | Stable |
 | Local Storage (non-CSI) | Local PV Hostpath | 4.6.0 | Stable |
-| Local Storage | Local PV LVM | 1.10.0 | Stable |
-| Local Storage | Local PV ZFS | 2.11.0 | Stable |
-| Local Storage | Local PV Rawfile | 0.15.0 | Experimental |
-| Other Components | CLI | 4.6.0 | — |
+| Local Storage | Local PV LVM | 1.10.1 | Stable |
+| Local Storage | Local PV ZFS | 2.11.1 | Stable |
+| Local Storage | Local PV Rawfile | 0.15.1 | Experimental |
+| Other Components | CLI | 4.6.1 | — |
 
 ## What’s New
 
@@ -69,6 +69,10 @@ The status of the various components as of v4.6 are as follows:
 
   Local PV ZFS StorageClasses now support the `atime` and `logbias` parameters, giving you direct control over access-time updates and write-workload optimisation on the underlying ZFS datasets and volumes.
 
+- **Format Options for Local PV LVM and Local PV ZFS**
+
+  The node component of both drivers now accepts `defaultFormatOptions`, giving the extra `mkfs` options a node uses for a filesystem when the StorageClass of a volume does not set `formatOptions`. This allows a cluster to format volumes safely without setting the options on every StorageClass. Local PV ZFS additionally gains the `formatOptions` StorageClass parameter, which Local PV LVM already supported. A StorageClass value replaces the default of its filesystem, the two are not merged, and no defaults ship with the charts.
+
 - **Topology-Constrained StorageClasses for Local PV Hostpath**
 
   The Local PV Hostpath Helm chart now allows you to set `allowedTopologies` on the provisioned StorageClass, so volume placement can be restricted to a defined set of nodes or zones directly from chart values.
@@ -107,6 +111,10 @@ The status of the various components as of v4.6 are as follows:
 
   Replica metrics now carry `pool_name` and `pool_uuid` labels, making it possible to attribute replica-level metrics to a specific DiskPool without additional correlation.
 
+- **Plugin Output Improvements**
+
+  The `kubectl mayastor` plugin now includes an `ID` column in its event output, and spurious error strings are no longer printed.
+
 ### Local Storage
 
 - **HTTP Health Probe for Local PV Hostpath**
@@ -124,6 +132,10 @@ The status of the various components as of v4.6 are as follows:
 - **Updated CSI Snapshot Components for Local PV LVM**
 
   The bundled `csi-snapshotter` and `snapshot-controller` components have been updated to v8.2.0.
+
+- **Updatable StorageClass and VolumeSnapshotClass for Local PV Rawfile**
+
+  The StorageClass and VolumeSnapshotClass created by the chart can now be modified with a `helm upgrade`.
 
 ## Fixes
 
@@ -161,6 +173,14 @@ The status of the various components as of v4.6 are as follows:
 
   Updated SPDK with fixes for a null pointer dereference and IPv6 transport handling, and resolved an interrupt-mode reactor teardown issue.
 
+- **Labels Containing Slashes on Delete, Cordon and Drain**
+
+  Resolved an issue where labels in the Kubernetes `domain/key` form were rejected by the delete, cordon, and drain REST routes.
+
+- **Support Bundle Collection Timeout**
+
+  Resolved an issue where Loki auto-discovery could time out while a support bundle was being collected. The default `--timeout` has also been raised from 10s to 30s.
+
 ### Local Storage
 
 - **Idempotent Volume Expansion for Local PV LVM**
@@ -186,6 +206,14 @@ The status of the various components as of v4.6 are as follows:
 - **Image URL Rendering for Local PV ZFS**
 
   Resolved an issue where image URLs in rendered manifests were not quoted, which could break rendering for registries whose URLs contain characters that YAML treats specially.
+
+- **Copy-on-Write Auto-Detection for Local PV Rawfile**
+
+  Resolved an issue where setting `copyOnWrite` to an empty string in the StorageClass was treated as `false` instead of auto-detecting the capability of the storage pool.
+
+- **Disabling the Local PV Rawfile Controller Deployment**
+
+  Resolved an issue where an incorrect Helm variable prevented the controller deployment from being disabled.
 
 ## Breaking Changes
 

--- a/docs/main/releases.md
+++ b/docs/main/releases.md
@@ -113,7 +113,7 @@ The status of the various components as of v4.6 are as follows:
 
 - **Plugin Output Improvements**
 
-  The `kubectl mayastor` plugin now includes an `ID` column in its event output, and spurious error strings are no longer printed.
+  The `kubectl-openebs mayastor get events` command now includes an `ID` column in its table output. Status messages are no longer written into the output of the command, so its JSON and YAML output can now be parsed and collected.
 
 ### Local Storage
 

--- a/docs/main/troubleshooting/troubleshooting-local-storage.md
+++ b/docs/main/troubleshooting/troubleshooting-local-storage.md
@@ -259,11 +259,69 @@ kubectl logs -n openebs -l openebs.io/component-name=openebs-localpv-provisioner
 
 ### Unable to mount `xfs` File System
 
-The volume is created, but `xfs` is failing to mount.
+The volume is created, but `xfs` fails to mount and the application pod stays in `ContainerCreating` with an event like this:
 
-**Workaround**
+```shell hideCopy
+MountVolume.SetUp failed for volume "pvc-0ac51f5a-ad2e-4540-afde-955ece4d46f4" :
+rpc error: code = Internal desc = failed to format and mount the volume error:
+mount failed: exit status 32
+Output: mount: ... wrong fs type, bad option, bad superblock on
+/dev/mapper/lvmvg-pvc--0ac51f5a--ad2e--4540--afde--955ece4d46f4 ...
+```
 
-If you are trying to use `xfs` volumes and the cluster node hosts are running a kernel version less than 5.10, you may encounter a mount failure of the filesystem. This is due to the incompatibility of newer `xfsprogs` options. In order to alleviate this issue, it is recommended to upgrade the host node kernel version to 5.10 or higher.
+**Troubleshooting**
+
+`mkfs.xfs` enables new on-disk features as it gets newer, and each feature needs a minimum kernel version to mount. When the `mkfs.xfs` inside the driver image is newer than the kernel of your nodes, the volume is formatted successfully and then cannot be mounted. The kernel log of the node names the feature:
+
+```shell hideCopy
+$ dmesg | tail -3
+XFS (dm-10): Superblock has unknown incompatible features (0x20) enabled.
+XFS (dm-10): Filesystem cannot be safely mounted by this kernel.
+XFS (dm-10): SB validate failed with error -22.
+```
+
+| Feature   | Enabled by default from | Minimum kernel |
+| :-------- | :---------------------- | :------------- |
+| `bigtime`, `inobtcount` | `mkfs.xfs` 5.15 | 5.10 |
+| `nrext64` (`0x20`) | `mkfs.xfs` 6.5 | 5.19 |
+
+**Resolution**
+
+Upgrading the nodes to a kernel that supports the feature is the preferred fix. If that is not possible, tell the driver to format `xfs` volumes without the feature.
+
+To apply it to every `xfs` volume in the cluster, set the default format options of the node component at install or upgrade time. For Local PV LVM:
+
+```
+helm upgrade --install lvm-localpv openebs/lvm-localpv -n openebs --create-namespace \
+  --set-string 'lvmNode.defaultFormatOptions.xfs=-i nrext64=0'
+```
+
+For Local PV ZFS:
+
+```
+helm upgrade --install zfs-localpv openebs/zfs-localpv -n openebs --create-namespace \
+  --set-string 'zfsNode.defaultFormatOptions.xfs=-i nrext64=0'
+```
+
+On a node whose kernel is older than 5.10, disable the earlier features as well:
+
+```
+--set-string 'lvmNode.defaultFormatOptions.xfs=-m bigtime=0,inobtcount=0 -i nrext64=0'
+```
+
+To apply it to a single StorageClass instead, use the `formatOptions` parameter:
+
+```yaml
+parameters:
+  fsType: "xfs"
+  formatOptions: "-i nrext64=0"
+```
+
+:::note
+Format options are applied only while a volume is being formatted, which happens the first time it is mounted. A volume that has already been formatted with an unsupported feature cannot be mounted on that node and has to be recreated.
+:::
+
+**See** [Node-Level Default Format Options for Local PV LVM](../user-guides/local-storage-user-guide/local-pv-lvm/configuration/lvm-storageclass-parameters.md#node-level-default-format-options) and [Node-Level Default Format Options for Local PV ZFS](../user-guides/local-storage-user-guide/local-pv-zfs/configuration/zfs-storageclass-parameters.md#node-level-default-format-options).
 
 ## See Also
 

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-lvm/configuration/lvm-storageclass-parameters.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-lvm/configuration/lvm-storageclass-parameters.md
@@ -90,10 +90,79 @@ Mount options are not applied to [raw block volumes](../advanced-operations/lvm-
 
   Refer to the documentation of the filesystem you are using to know which format options it supports.
 
+  To apply the same options to every volume of a filesystem across the cluster instead of per StorageClass, see [Node-Level Default Format Options](#node-level-default-format-options).
+
 :::note
 Format options are not validated by the driver. If the options are not valid for the chosen filesystem, then formatting fails and the volume does not mount.
 
 Format options are also not applied to [raw block volumes](../advanced-operations/lvm-raw-block-volume.md), because a raw block volume is not formatted with a filesystem.
+:::
+
+## Node-Level Default Format Options
+
+`formatOptions` sets the extra `mkfs` options of a single StorageClass. To apply options to every volume of a filesystem across the cluster instead, the node component takes `defaultFormatOptions`. This is a Helm value set when you install or upgrade the driver, not a StorageClass parameter. Use it when an option is a property of your nodes rather than of one workload, such as a `mkfs.xfs` option that the kernel of your nodes requires.
+
+Give `lvmNode.defaultFormatOptions` one entry per filesystem. The key is a filesystem the driver formats (`ext2`, `ext3`, `ext4`, `xfs` or `btrfs`) and the value is that filesystem's `mkfs` options as a single space-separated string.
+
+```yaml
+lvmNode:
+  defaultFormatOptions:
+    ext4: "-m 0 -O ^orphan_file"
+    xfs: "-i nrext64=0"
+```
+
+Install or upgrade with the values file:
+
+```
+helm upgrade --install lvm-localpv openebs/lvm-localpv -n openebs --create-namespace -f values.yaml
+```
+
+A single filesystem can also be set on the command line. Use `--set-string`, because the value contains spaces and an `=` sign:
+
+```
+helm upgrade --install lvm-localpv openebs/lvm-localpv -n openebs --create-namespace \
+  --set-string 'lvmNode.defaultFormatOptions.xfs=-i nrext64=0'
+```
+
+The chart turns each entry into one `--default-format-options=<fstype>=<options>` argument of the node plugin and rolls the node DaemonSet. Filesystems whose value is empty are skipped. The chart ships no defaults, and a mistyped or unknown filesystem entry fails the node agent at startup instead of formatting volumes the node cannot mount.
+
+### How DefaultFormatOptions and FormatOptions Interact
+
+For each volume the driver resolves one set of options for the filesystem it is about to create:
+
+1. If the StorageClass of the volume sets `formatOptions`, those options are used.
+2. Otherwise the `defaultFormatOptions` entry of that filesystem is used.
+3. If neither is set, the volume is formatted with the defaults of `mkfs`.
+
+The two are **not merged**. A StorageClass that sets `formatOptions` replaces the default of its filesystem completely, so a StorageClass that needs both its own option and a node wide one has to repeat the node wide one:
+
+```yaml
+parameters:
+  storage: "lvm"
+  volgroup: "lvmvg"
+  fsType: "xfs"
+  formatOptions: "-i nrext64=0 -b size=4096"   ## repeats the node wide -i nrext64=0
+```
+
+The options are applied only while a volume is being formatted, which happens the first time it is mounted. Changing `defaultFormatOptions` therefore affects volumes provisioned after the change, and never reformats a volume that already carries a filesystem.
+
+### Verifying the Configuration
+
+Confirm that the node plugin received the arguments:
+
+```
+$ kubectl get pod -n openebs -l app=openebs-lvm-node \
+    -o jsonpath='{.items[0].spec.containers[?(@.name=="openebs-lvm-plugin")].args}'
+```
+
+After a volume of that filesystem is mounted for the first time, the node plugin log shows the options it passed to `mkfs`:
+
+```
+$ kubectl logs -n openebs -l app=openebs-lvm-node -c openebs-lvm-plugin | grep "attempting to format"
+```
+
+:::note
+If an `xfs` volume fails to mount after provisioning because the `mkfs.xfs` in the driver image is newer than the kernel of your nodes, see [Unable to mount xfs File System](../../../../troubleshooting/troubleshooting-local-storage.md#unable-to-mount-xfs-file-system).
 :::
 
 ## Shared (Optional)

--- a/docs/main/user-guides/local-storage-user-guide/local-pv-zfs/configuration/zfs-storageclass-parameters.md
+++ b/docs/main/user-guides/local-storage-user-guide/local-pv-zfs/configuration/zfs-storageclass-parameters.md
@@ -34,6 +34,7 @@ These parameters are set under `parameters` in the StorageClass.
 |-----------|-------------|----------------|------------|
 | `poolname` | Required | Existing ZFS pool or child dataset (for example, `zfspv-pool`, `zfspv-pool/child`) | Both |
 | `fstype` | Optional | `zfs`, `ext2`, `ext3`, `ext4`, `xfs`, `btrfs` | Both |
+| `formatOptions` | Optional | Extra `mkfs` options as a space-separated string | ZVOL |
 | `recordsize` | Optional | Any power of 2 from 512 bytes to 128 KiB | Dataset |
 | `volblocksize` | Optional | Any power of 2 from 512 bytes to 128 KiB | ZVOL |
 | `compression` | Optional | `on`, `off`, `lzjb`, `lz4`, `zle`, `gzip`, `gzip-1` through `gzip-9`, `zstd`, `zstd-fast`, `zstd-1` through `zstd-19` | Both |
@@ -69,6 +70,103 @@ FsType specifies filesystem type for the zfs volume/dataset. If FsType is provid
 not required as underlying filesystem is ZFS anyway. If FsType is ext2, ext3, ext4, btrfs, or xfs, then the driver will create a ZVOL and format the volume
 accordingly. FsType can not be modified once volume has been provisioned. If fstype is not provided, k8s takes ext4 as the default fstype.
 
+
+## FormatOptions (Optional Parameter)
+
+Use the `formatOptions` parameter to pass extra options to the `mkfs` command that formats the ZVOL with the filesystem specified by `fstype`. Provide the options as a single space-separated string.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-zfspv
+allowVolumeExpansion: true
+parameters:
+  poolname: "zfspv-pool"
+  fstype: "xfs"
+  formatOptions: "-i nrext64=0"      ## Extra mkfs options for ZVOL backed volumes
+provisioner: zfs.csi.openebs.io
+```
+
+The options are applied only while the volume is being formatted, which happens the first time the volume is mounted. Changing `formatOptions` in the storage class has no effect on volumes that have already been formatted.
+
+Refer to the documentation of the filesystem you are using to know which format options it supports.
+
+To apply the same options to every volume of a filesystem across the cluster instead of per StorageClass, see [Node-Level Default Format Options](#node-level-default-format-options).
+
+:::note
+Format options apply only to ZVOL backed volumes. A StorageClass with `fstype: "zfs"` gets a ZFS dataset, which is not formatted with `mkfs`, so `formatOptions` has no effect on it.
+
+Format options are not validated by the driver. If the options are not valid for the chosen filesystem, then formatting fails and the volume does not mount.
+
+Format options are also not applied to [raw block volumes](../advanced-operations/zfs-raw-block-volume.md), because a raw block volume is not formatted with a filesystem.
+:::
+
+## Node-Level Default Format Options
+
+`formatOptions` sets the extra `mkfs` options of a single StorageClass. To apply options to every volume of a filesystem across the cluster instead, the node component takes `defaultFormatOptions`. This is a Helm value set when you install or upgrade the driver, not a StorageClass parameter. Use it when an option is a property of your nodes rather than of one workload, such as a `mkfs.xfs` option that the kernel of your nodes requires.
+
+Give `zfsNode.defaultFormatOptions` one entry per filesystem. The key is a filesystem the driver formats (`ext2`, `ext3`, `ext4`, `xfs` or `btrfs`) and the value is that filesystem's `mkfs` options as a single space-separated string.
+
+```yaml
+zfsNode:
+  defaultFormatOptions:
+    ext4: "-m 0 -O ^orphan_file"
+    xfs: "-i nrext64=0"
+```
+
+Install or upgrade with the values file:
+
+```
+helm upgrade --install zfs-localpv openebs/zfs-localpv -n openebs --create-namespace -f values.yaml
+```
+
+A single filesystem can also be set on the command line. Use `--set-string`, because the value contains spaces and an `=` sign:
+
+```
+helm upgrade --install zfs-localpv openebs/zfs-localpv -n openebs --create-namespace \
+  --set-string 'zfsNode.defaultFormatOptions.xfs=-i nrext64=0'
+```
+
+The chart turns each entry into one `--default-format-options=<fstype>=<options>` argument of the node plugin and rolls the node DaemonSet. Filesystems whose value is empty are skipped. The chart ships no defaults.
+
+### How DefaultFormatOptions and FormatOptions Interact
+
+For each volume the driver resolves one set of options for the filesystem it is about to create:
+
+1. If the StorageClass of the volume sets `formatOptions`, those options are used.
+2. Otherwise the `defaultFormatOptions` entry of that filesystem is used.
+3. If neither is set, the volume is formatted with the defaults of `mkfs`.
+
+The two are **not merged**. A StorageClass that sets `formatOptions` replaces the default of its filesystem completely, so a StorageClass that needs both its own option and a node wide one has to repeat the node wide one:
+
+```yaml
+parameters:
+  poolname: "zfspv-pool"
+  fstype: "xfs"
+  formatOptions: "-i nrext64=0 -b size=4096"   ## repeats the node wide -i nrext64=0
+```
+
+The options are applied only while a volume is being formatted, which happens the first time it is mounted. Changing `defaultFormatOptions` therefore affects volumes provisioned after the change, and never reformats a volume that already carries a filesystem.
+
+### Verifying the Configuration
+
+Confirm that the node plugin received the arguments:
+
+```
+$ kubectl get pod -n openebs -l app=openebs-zfs-node \
+    -o jsonpath='{.items[0].spec.containers[?(@.name=="openebs-zfs-plugin")].args}'
+```
+
+After a volume of that filesystem is mounted for the first time, the node plugin log shows the options it passed to `mkfs`:
+
+```
+$ kubectl logs -n openebs -l app=openebs-zfs-node -c openebs-zfs-plugin | grep "attempting to format"
+```
+
+:::note
+If an `xfs` volume fails to mount after provisioning because the `mkfs.xfs` in the driver image is newer than the kernel of your nodes, see [Unable to mount xfs File System](../../../../troubleshooting/troubleshooting-local-storage.md#unable-to-mount-xfs-file-system).
+:::
 
 ## Recordsize (Optional Parameter)
 

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/eventing-aggregator.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/eventing-aggregator.md
@@ -111,10 +111,10 @@ kubectl openebs mayastor get events -n <product-namespace>
 **Sample Output**
 
 ```
-TIMESTAMP             CATEGORY  ACTION         TARGET                                NODE      COMPONENT
-2026-08-12T09:14:02Z  volume    create         18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  CoreAgent
-2026-08-12T09:14:03Z  replica   create         c0f9a1d2-77b3-4a51-9e0c-1b2a3c4d5e6f  worker-2  IoEngine
-2026-08-12T09:18:47Z  nexus     rebuild_begin  18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  IoEngine
+ID                                    TIMESTAMP             CATEGORY  ACTION         TARGET                                NODE      COMPONENT
+7c1e4f80-2a55-4c1e-9c7a-51d0e6a3b911  2026-08-12T09:14:02Z  volume    create         18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  CoreAgent
+9b2d7e13-6f04-4a8b-bd21-0c93f5a7e442  2026-08-12T09:14:03Z  replica   create         c0f9a1d2-77b3-4a51-9e0c-1b2a3c4d5e6f  worker-2  IoEngine
+a4f60c25-91bb-4d37-8e5f-2d7c8b1a9e03  2026-08-12T09:18:47Z  nexus     rebuild_begin  18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  IoEngine
 ```
 
 By default, the command returns events from the last 24 hours, up to a maximum of 1000 records.

--- a/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/kubectl-plugin.md
+++ b/docs/main/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/kubectl-plugin.md
@@ -191,9 +191,9 @@ kubectl openebs mayastor get events
 **Expected Output**
 
 ```
-TIMESTAMP             CATEGORY  ACTION         TARGET                                NODE      COMPONENT
-2026-08-12T09:14:02Z  volume    create         18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  CoreAgent
-2026-08-12T09:18:47Z  nexus     rebuild_begin  18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  IoEngine
+ID                                    TIMESTAMP             CATEGORY  ACTION         TARGET                                NODE      COMPONENT
+7c1e4f80-2a55-4c1e-9c7a-51d0e6a3b911  2026-08-12T09:14:02Z  volume    create         18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  CoreAgent
+a4f60c25-91bb-4d37-8e5f-2d7c8b1a9e03  2026-08-12T09:18:47Z  nexus     rebuild_begin  18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  IoEngine
 ```
 
 This command returns events collected by the Eventing Aggregator. It supports filtering by category, action, component, node, pool, volume, and replica, among others. Refer to the [Eventing Aggregator](eventing-aggregator.md) documentation for the complete set of options.

--- a/docs/main/user-guides/supportability.md
+++ b/docs/main/user-guides/supportability.md
@@ -39,7 +39,7 @@ Commands:
 
 Options:
   -t, --timeout <TIMEOUT>
-          Specifies the timeout value to interact with other modules of system [default: 10s]
+          Specifies the timeout value to interact with other modules of system [default: 30s]
   -s, --since <SINCE>
           Period states to collect all logs from last specified duration [default: 24h]
   -l, --loki-endpoint <LOKI_ENDPOINT>

--- a/docs/versioned_docs/version-4.6.x/releases.md
+++ b/docs/versioned_docs/version-4.6.x/releases.md
@@ -113,7 +113,7 @@ The status of the various components as of v4.6 are as follows:
 
 - **Plugin Output Improvements**
 
-  The `kubectl mayastor` plugin now includes an `ID` column in its event output, and spurious error strings are no longer printed.
+  The `kubectl-openebs mayastor get events` command now includes an `ID` column in its table output. Status messages are no longer written into the output of the command, so its JSON and YAML output can now be parsed and collected.
 
 ### Local Storage
 

--- a/docs/versioned_docs/version-4.6.x/releases.md
+++ b/docs/versioned_docs/version-4.6.x/releases.md
@@ -16,12 +16,12 @@ The status of the various components as of v4.6 are as follows:
 
 | Component Type | Component | Version | Status |
 | :--- | :--- | :--- | :--- |
-| Replicated Storage | Replicated PV Mayastor | 2.12.0 | Stable |
+| Replicated Storage | Replicated PV Mayastor | 2.12.1 | Stable |
 | Local Storage (non-CSI) | Local PV Hostpath | 4.6.0 | Stable |
-| Local Storage | Local PV LVM | 1.10.0 | Stable |
-| Local Storage | Local PV ZFS | 2.11.0 | Stable |
-| Local Storage | Local PV Rawfile | 0.15.0 | Experimental |
-| Other Components | CLI | 4.6.0 | — |
+| Local Storage | Local PV LVM | 1.10.1 | Stable |
+| Local Storage | Local PV ZFS | 2.11.1 | Stable |
+| Local Storage | Local PV Rawfile | 0.15.1 | Experimental |
+| Other Components | CLI | 4.6.1 | — |
 
 ## What’s New
 
@@ -69,6 +69,10 @@ The status of the various components as of v4.6 are as follows:
 
   Local PV ZFS StorageClasses now support the `atime` and `logbias` parameters, giving you direct control over access-time updates and write-workload optimisation on the underlying ZFS datasets and volumes.
 
+- **Format Options for Local PV LVM and Local PV ZFS**
+
+  The node component of both drivers now accepts `defaultFormatOptions`, giving the extra `mkfs` options a node uses for a filesystem when the StorageClass of a volume does not set `formatOptions`. This allows a cluster to format volumes safely without setting the options on every StorageClass. Local PV ZFS additionally gains the `formatOptions` StorageClass parameter, which Local PV LVM already supported. A StorageClass value replaces the default of its filesystem, the two are not merged, and no defaults ship with the charts.
+
 - **Topology-Constrained StorageClasses for Local PV Hostpath**
 
   The Local PV Hostpath Helm chart now allows you to set `allowedTopologies` on the provisioned StorageClass, so volume placement can be restricted to a defined set of nodes or zones directly from chart values.
@@ -107,6 +111,10 @@ The status of the various components as of v4.6 are as follows:
 
   Replica metrics now carry `pool_name` and `pool_uuid` labels, making it possible to attribute replica-level metrics to a specific DiskPool without additional correlation.
 
+- **Plugin Output Improvements**
+
+  The `kubectl mayastor` plugin now includes an `ID` column in its event output, and spurious error strings are no longer printed.
+
 ### Local Storage
 
 - **HTTP Health Probe for Local PV Hostpath**
@@ -124,6 +132,10 @@ The status of the various components as of v4.6 are as follows:
 - **Updated CSI Snapshot Components for Local PV LVM**
 
   The bundled `csi-snapshotter` and `snapshot-controller` components have been updated to v8.2.0.
+
+- **Updatable StorageClass and VolumeSnapshotClass for Local PV Rawfile**
+
+  The StorageClass and VolumeSnapshotClass created by the chart can now be modified with a `helm upgrade`.
 
 ## Fixes
 
@@ -161,6 +173,14 @@ The status of the various components as of v4.6 are as follows:
 
   Updated SPDK with fixes for a null pointer dereference and IPv6 transport handling, and resolved an interrupt-mode reactor teardown issue.
 
+- **Labels Containing Slashes on Delete, Cordon and Drain**
+
+  Resolved an issue where labels in the Kubernetes `domain/key` form were rejected by the delete, cordon, and drain REST routes.
+
+- **Support Bundle Collection Timeout**
+
+  Resolved an issue where Loki auto-discovery could time out while a support bundle was being collected. The default `--timeout` has also been raised from 10s to 30s.
+
 ### Local Storage
 
 - **Idempotent Volume Expansion for Local PV LVM**
@@ -186,6 +206,14 @@ The status of the various components as of v4.6 are as follows:
 - **Image URL Rendering for Local PV ZFS**
 
   Resolved an issue where image URLs in rendered manifests were not quoted, which could break rendering for registries whose URLs contain characters that YAML treats specially.
+
+- **Copy-on-Write Auto-Detection for Local PV Rawfile**
+
+  Resolved an issue where setting `copyOnWrite` to an empty string in the StorageClass was treated as `false` instead of auto-detecting the capability of the storage pool.
+
+- **Disabling the Local PV Rawfile Controller Deployment**
+
+  Resolved an issue where an incorrect Helm variable prevented the controller deployment from being disabled.
 
 ## Breaking Changes
 
@@ -236,7 +264,7 @@ This issue is not caused by Mayastor but is triggered more frequently because of
 
 ## Related Information
 
-OpenEBS Release notes are maintained in the GitHub repositories alongside the code and releases. For release summaries and full version-level notes, see [OpenEBS Release 4.6](https://github.com/openebs/openebs/releases#release-v4.6.0).
+OpenEBS Release notes are maintained in the GitHub repositories alongside the code and releases. For release summaries and full version-level notes, see [OpenEBS Release 4.6](https://github.com/openebs/openebs/releases#release-v4.6.1).
 
 See version specific Releases to view the legacy OpenEBS Releases.
 

--- a/docs/versioned_docs/version-4.6.x/troubleshooting/troubleshooting-local-storage.md
+++ b/docs/versioned_docs/version-4.6.x/troubleshooting/troubleshooting-local-storage.md
@@ -259,11 +259,69 @@ kubectl logs -n openebs -l openebs.io/component-name=openebs-localpv-provisioner
 
 ### Unable to mount `xfs` File System
 
-The volume is created, but `xfs` is failing to mount.
+The volume is created, but `xfs` fails to mount and the application pod stays in `ContainerCreating` with an event like this:
 
-**Workaround**
+```shell hideCopy
+MountVolume.SetUp failed for volume "pvc-0ac51f5a-ad2e-4540-afde-955ece4d46f4" :
+rpc error: code = Internal desc = failed to format and mount the volume error:
+mount failed: exit status 32
+Output: mount: ... wrong fs type, bad option, bad superblock on
+/dev/mapper/lvmvg-pvc--0ac51f5a--ad2e--4540--afde--955ece4d46f4 ...
+```
 
-If you are trying to use `xfs` volumes and the cluster node hosts are running a kernel version less than 5.10, you may encounter a mount failure of the filesystem. This is due to the incompatibility of newer `xfsprogs` options. In order to alleviate this issue, it is recommended to upgrade the host node kernel version to 5.10 or higher.
+**Troubleshooting**
+
+`mkfs.xfs` enables new on-disk features as it gets newer, and each feature needs a minimum kernel version to mount. When the `mkfs.xfs` inside the driver image is newer than the kernel of your nodes, the volume is formatted successfully and then cannot be mounted. The kernel log of the node names the feature:
+
+```shell hideCopy
+$ dmesg | tail -3
+XFS (dm-10): Superblock has unknown incompatible features (0x20) enabled.
+XFS (dm-10): Filesystem cannot be safely mounted by this kernel.
+XFS (dm-10): SB validate failed with error -22.
+```
+
+| Feature   | Enabled by default from | Minimum kernel |
+| :-------- | :---------------------- | :------------- |
+| `bigtime`, `inobtcount` | `mkfs.xfs` 5.15 | 5.10 |
+| `nrext64` (`0x20`) | `mkfs.xfs` 6.5 | 5.19 |
+
+**Resolution**
+
+Upgrading the nodes to a kernel that supports the feature is the preferred fix. If that is not possible, tell the driver to format `xfs` volumes without the feature.
+
+To apply it to every `xfs` volume in the cluster, set the default format options of the node component at install or upgrade time. For Local PV LVM:
+
+```
+helm upgrade --install lvm-localpv openebs/lvm-localpv -n openebs --create-namespace \
+  --set-string 'lvmNode.defaultFormatOptions.xfs=-i nrext64=0'
+```
+
+For Local PV ZFS:
+
+```
+helm upgrade --install zfs-localpv openebs/zfs-localpv -n openebs --create-namespace \
+  --set-string 'zfsNode.defaultFormatOptions.xfs=-i nrext64=0'
+```
+
+On a node whose kernel is older than 5.10, disable the earlier features as well:
+
+```
+--set-string 'lvmNode.defaultFormatOptions.xfs=-m bigtime=0,inobtcount=0 -i nrext64=0'
+```
+
+To apply it to a single StorageClass instead, use the `formatOptions` parameter:
+
+```yaml
+parameters:
+  fsType: "xfs"
+  formatOptions: "-i nrext64=0"
+```
+
+:::note
+Format options are applied only while a volume is being formatted, which happens the first time it is mounted. A volume that has already been formatted with an unsupported feature cannot be mounted on that node and has to be recreated.
+:::
+
+**See** [Node-Level Default Format Options for Local PV LVM](../user-guides/local-storage-user-guide/local-pv-lvm/configuration/lvm-storageclass-parameters.md#node-level-default-format-options) and [Node-Level Default Format Options for Local PV ZFS](../user-guides/local-storage-user-guide/local-pv-zfs/configuration/zfs-storageclass-parameters.md#node-level-default-format-options).
 
 ## See Also
 

--- a/docs/versioned_docs/version-4.6.x/user-guides/local-storage-user-guide/local-pv-lvm/configuration/lvm-storageclass-parameters.md
+++ b/docs/versioned_docs/version-4.6.x/user-guides/local-storage-user-guide/local-pv-lvm/configuration/lvm-storageclass-parameters.md
@@ -90,10 +90,79 @@ Mount options are not applied to [raw block volumes](../advanced-operations/lvm-
 
   Refer to the documentation of the filesystem you are using to know which format options it supports.
 
+  To apply the same options to every volume of a filesystem across the cluster instead of per StorageClass, see [Node-Level Default Format Options](#node-level-default-format-options).
+
 :::note
 Format options are not validated by the driver. If the options are not valid for the chosen filesystem, then formatting fails and the volume does not mount.
 
 Format options are also not applied to [raw block volumes](../advanced-operations/lvm-raw-block-volume.md), because a raw block volume is not formatted with a filesystem.
+:::
+
+## Node-Level Default Format Options
+
+`formatOptions` sets the extra `mkfs` options of a single StorageClass. To apply options to every volume of a filesystem across the cluster instead, the node component takes `defaultFormatOptions`. This is a Helm value set when you install or upgrade the driver, not a StorageClass parameter. Use it when an option is a property of your nodes rather than of one workload, such as a `mkfs.xfs` option that the kernel of your nodes requires.
+
+Give `lvmNode.defaultFormatOptions` one entry per filesystem. The key is a filesystem the driver formats (`ext2`, `ext3`, `ext4`, `xfs` or `btrfs`) and the value is that filesystem's `mkfs` options as a single space-separated string.
+
+```yaml
+lvmNode:
+  defaultFormatOptions:
+    ext4: "-m 0 -O ^orphan_file"
+    xfs: "-i nrext64=0"
+```
+
+Install or upgrade with the values file:
+
+```
+helm upgrade --install lvm-localpv openebs/lvm-localpv -n openebs --create-namespace -f values.yaml
+```
+
+A single filesystem can also be set on the command line. Use `--set-string`, because the value contains spaces and an `=` sign:
+
+```
+helm upgrade --install lvm-localpv openebs/lvm-localpv -n openebs --create-namespace \
+  --set-string 'lvmNode.defaultFormatOptions.xfs=-i nrext64=0'
+```
+
+The chart turns each entry into one `--default-format-options=<fstype>=<options>` argument of the node plugin and rolls the node DaemonSet. Filesystems whose value is empty are skipped. The chart ships no defaults, and a mistyped or unknown filesystem entry fails the node agent at startup instead of formatting volumes the node cannot mount.
+
+### How DefaultFormatOptions and FormatOptions Interact
+
+For each volume the driver resolves one set of options for the filesystem it is about to create:
+
+1. If the StorageClass of the volume sets `formatOptions`, those options are used.
+2. Otherwise the `defaultFormatOptions` entry of that filesystem is used.
+3. If neither is set, the volume is formatted with the defaults of `mkfs`.
+
+The two are **not merged**. A StorageClass that sets `formatOptions` replaces the default of its filesystem completely, so a StorageClass that needs both its own option and a node wide one has to repeat the node wide one:
+
+```yaml
+parameters:
+  storage: "lvm"
+  volgroup: "lvmvg"
+  fsType: "xfs"
+  formatOptions: "-i nrext64=0 -b size=4096"   ## repeats the node wide -i nrext64=0
+```
+
+The options are applied only while a volume is being formatted, which happens the first time it is mounted. Changing `defaultFormatOptions` therefore affects volumes provisioned after the change, and never reformats a volume that already carries a filesystem.
+
+### Verifying the Configuration
+
+Confirm that the node plugin received the arguments:
+
+```
+$ kubectl get pod -n openebs -l app=openebs-lvm-node \
+    -o jsonpath='{.items[0].spec.containers[?(@.name=="openebs-lvm-plugin")].args}'
+```
+
+After a volume of that filesystem is mounted for the first time, the node plugin log shows the options it passed to `mkfs`:
+
+```
+$ kubectl logs -n openebs -l app=openebs-lvm-node -c openebs-lvm-plugin | grep "attempting to format"
+```
+
+:::note
+If an `xfs` volume fails to mount after provisioning because the `mkfs.xfs` in the driver image is newer than the kernel of your nodes, see [Unable to mount xfs File System](../../../../troubleshooting/troubleshooting-local-storage.md#unable-to-mount-xfs-file-system).
 :::
 
 ## Shared (Optional)

--- a/docs/versioned_docs/version-4.6.x/user-guides/local-storage-user-guide/local-pv-zfs/configuration/zfs-storageclass-parameters.md
+++ b/docs/versioned_docs/version-4.6.x/user-guides/local-storage-user-guide/local-pv-zfs/configuration/zfs-storageclass-parameters.md
@@ -34,6 +34,7 @@ These parameters are set under `parameters` in the StorageClass.
 |-----------|-------------|----------------|------------|
 | `poolname` | Required | Existing ZFS pool or child dataset (for example, `zfspv-pool`, `zfspv-pool/child`) | Both |
 | `fstype` | Optional | `zfs`, `ext2`, `ext3`, `ext4`, `xfs`, `btrfs` | Both |
+| `formatOptions` | Optional | Extra `mkfs` options as a space-separated string | ZVOL |
 | `recordsize` | Optional | Any power of 2 from 512 bytes to 128 KiB | Dataset |
 | `volblocksize` | Optional | Any power of 2 from 512 bytes to 128 KiB | ZVOL |
 | `compression` | Optional | `on`, `off`, `lzjb`, `lz4`, `zle`, `gzip`, `gzip-1` through `gzip-9`, `zstd`, `zstd-fast`, `zstd-1` through `zstd-19` | Both |
@@ -69,6 +70,103 @@ FsType specifies filesystem type for the zfs volume/dataset. If FsType is provid
 not required as underlying filesystem is ZFS anyway. If FsType is ext2, ext3, ext4, btrfs, or xfs, then the driver will create a ZVOL and format the volume
 accordingly. FsType can not be modified once volume has been provisioned. If fstype is not provided, k8s takes ext4 as the default fstype.
 
+
+## FormatOptions (Optional Parameter)
+
+Use the `formatOptions` parameter to pass extra options to the `mkfs` command that formats the ZVOL with the filesystem specified by `fstype`. Provide the options as a single space-separated string.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-zfspv
+allowVolumeExpansion: true
+parameters:
+  poolname: "zfspv-pool"
+  fstype: "xfs"
+  formatOptions: "-i nrext64=0"      ## Extra mkfs options for ZVOL backed volumes
+provisioner: zfs.csi.openebs.io
+```
+
+The options are applied only while the volume is being formatted, which happens the first time the volume is mounted. Changing `formatOptions` in the storage class has no effect on volumes that have already been formatted.
+
+Refer to the documentation of the filesystem you are using to know which format options it supports.
+
+To apply the same options to every volume of a filesystem across the cluster instead of per StorageClass, see [Node-Level Default Format Options](#node-level-default-format-options).
+
+:::note
+Format options apply only to ZVOL backed volumes. A StorageClass with `fstype: "zfs"` gets a ZFS dataset, which is not formatted with `mkfs`, so `formatOptions` has no effect on it.
+
+Format options are not validated by the driver. If the options are not valid for the chosen filesystem, then formatting fails and the volume does not mount.
+
+Format options are also not applied to [raw block volumes](../advanced-operations/zfs-raw-block-volume.md), because a raw block volume is not formatted with a filesystem.
+:::
+
+## Node-Level Default Format Options
+
+`formatOptions` sets the extra `mkfs` options of a single StorageClass. To apply options to every volume of a filesystem across the cluster instead, the node component takes `defaultFormatOptions`. This is a Helm value set when you install or upgrade the driver, not a StorageClass parameter. Use it when an option is a property of your nodes rather than of one workload, such as a `mkfs.xfs` option that the kernel of your nodes requires.
+
+Give `zfsNode.defaultFormatOptions` one entry per filesystem. The key is a filesystem the driver formats (`ext2`, `ext3`, `ext4`, `xfs` or `btrfs`) and the value is that filesystem's `mkfs` options as a single space-separated string.
+
+```yaml
+zfsNode:
+  defaultFormatOptions:
+    ext4: "-m 0 -O ^orphan_file"
+    xfs: "-i nrext64=0"
+```
+
+Install or upgrade with the values file:
+
+```
+helm upgrade --install zfs-localpv openebs/zfs-localpv -n openebs --create-namespace -f values.yaml
+```
+
+A single filesystem can also be set on the command line. Use `--set-string`, because the value contains spaces and an `=` sign:
+
+```
+helm upgrade --install zfs-localpv openebs/zfs-localpv -n openebs --create-namespace \
+  --set-string 'zfsNode.defaultFormatOptions.xfs=-i nrext64=0'
+```
+
+The chart turns each entry into one `--default-format-options=<fstype>=<options>` argument of the node plugin and rolls the node DaemonSet. Filesystems whose value is empty are skipped. The chart ships no defaults.
+
+### How DefaultFormatOptions and FormatOptions Interact
+
+For each volume the driver resolves one set of options for the filesystem it is about to create:
+
+1. If the StorageClass of the volume sets `formatOptions`, those options are used.
+2. Otherwise the `defaultFormatOptions` entry of that filesystem is used.
+3. If neither is set, the volume is formatted with the defaults of `mkfs`.
+
+The two are **not merged**. A StorageClass that sets `formatOptions` replaces the default of its filesystem completely, so a StorageClass that needs both its own option and a node wide one has to repeat the node wide one:
+
+```yaml
+parameters:
+  poolname: "zfspv-pool"
+  fstype: "xfs"
+  formatOptions: "-i nrext64=0 -b size=4096"   ## repeats the node wide -i nrext64=0
+```
+
+The options are applied only while a volume is being formatted, which happens the first time it is mounted. Changing `defaultFormatOptions` therefore affects volumes provisioned after the change, and never reformats a volume that already carries a filesystem.
+
+### Verifying the Configuration
+
+Confirm that the node plugin received the arguments:
+
+```
+$ kubectl get pod -n openebs -l app=openebs-zfs-node \
+    -o jsonpath='{.items[0].spec.containers[?(@.name=="openebs-zfs-plugin")].args}'
+```
+
+After a volume of that filesystem is mounted for the first time, the node plugin log shows the options it passed to `mkfs`:
+
+```
+$ kubectl logs -n openebs -l app=openebs-zfs-node -c openebs-zfs-plugin | grep "attempting to format"
+```
+
+:::note
+If an `xfs` volume fails to mount after provisioning because the `mkfs.xfs` in the driver image is newer than the kernel of your nodes, see [Unable to mount xfs File System](../../../../troubleshooting/troubleshooting-local-storage.md#unable-to-mount-xfs-file-system).
+:::
 
 ## Recordsize (Optional Parameter)
 

--- a/docs/versioned_docs/version-4.6.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/eventing-aggregator.md
+++ b/docs/versioned_docs/version-4.6.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/eventing-aggregator.md
@@ -111,10 +111,10 @@ kubectl openebs mayastor get events -n <product-namespace>
 **Sample Output**
 
 ```
-TIMESTAMP             CATEGORY  ACTION         TARGET                                NODE      COMPONENT
-2026-08-12T09:14:02Z  volume    create         18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  CoreAgent
-2026-08-12T09:14:03Z  replica   create         c0f9a1d2-77b3-4a51-9e0c-1b2a3c4d5e6f  worker-2  IoEngine
-2026-08-12T09:18:47Z  nexus     rebuild_begin  18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  IoEngine
+ID                                    TIMESTAMP             CATEGORY  ACTION         TARGET                                NODE      COMPONENT
+7c1e4f80-2a55-4c1e-9c7a-51d0e6a3b911  2026-08-12T09:14:02Z  volume    create         18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  CoreAgent
+9b2d7e13-6f04-4a8b-bd21-0c93f5a7e442  2026-08-12T09:14:03Z  replica   create         c0f9a1d2-77b3-4a51-9e0c-1b2a3c4d5e6f  worker-2  IoEngine
+a4f60c25-91bb-4d37-8e5f-2d7c8b1a9e03  2026-08-12T09:18:47Z  nexus     rebuild_begin  18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  IoEngine
 ```
 
 By default, the command returns events from the last 24 hours, up to a maximum of 1000 records.

--- a/docs/versioned_docs/version-4.6.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/kubectl-plugin.md
+++ b/docs/versioned_docs/version-4.6.x/user-guides/replicated-storage-user-guide/replicated-pv-mayastor/advanced-operations/kubectl-plugin.md
@@ -191,9 +191,9 @@ kubectl openebs mayastor get events
 **Expected Output**
 
 ```
-TIMESTAMP             CATEGORY  ACTION         TARGET                                NODE      COMPONENT
-2026-08-12T09:14:02Z  volume    create         18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  CoreAgent
-2026-08-12T09:18:47Z  nexus     rebuild_begin  18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  IoEngine
+ID                                    TIMESTAMP             CATEGORY  ACTION         TARGET                                NODE      COMPONENT
+7c1e4f80-2a55-4c1e-9c7a-51d0e6a3b911  2026-08-12T09:14:02Z  volume    create         18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  CoreAgent
+a4f60c25-91bb-4d37-8e5f-2d7c8b1a9e03  2026-08-12T09:18:47Z  nexus     rebuild_begin  18e30e83-b106-4e0d-9fb6-2b04e761e18a  worker-1  IoEngine
 ```
 
 This command returns events collected by the Eventing Aggregator. It supports filtering by category, action, component, node, pool, volume, and replica, among others. Refer to the [Eventing Aggregator](eventing-aggregator.md) documentation for the complete set of options.

--- a/docs/versioned_docs/version-4.6.x/user-guides/supportability.md
+++ b/docs/versioned_docs/version-4.6.x/user-guides/supportability.md
@@ -39,7 +39,7 @@ Commands:
 
 Options:
   -t, --timeout <TIMEOUT>
-          Specifies the timeout value to interact with other modules of system [default: 10s]
+          Specifies the timeout value to interact with other modules of system [default: 30s]
   -s, --since <SINCE>
           Period states to collect all logs from last specified duration [default: 24h]
   -l, --loki-endpoint <LOKI_ENDPOINT>


### PR DESCRIPTION
## Summary

Documents the OpenEBS 4.6.1 patch release: Replicated PV Mayastor 2.12.1,
Local PV LVM 1.10.1, Local PV ZFS 2.11.1 and Local PV Rawfile 0.15.1.
Applied to both `docs/main` and `docs/versioned_docs/version-4.6.x`.

## Format options (LVM and ZFS)

- **ZFS `formatOptions`** - new StorageClass parameter in 2.11.1, documented
  in `zfs-storageclass-parameters.md` with a table row and its own section.
- **Node-level `defaultFormatOptions`** - new Helm value on the node component
  of both drivers, documented in each engine's StorageClass Parameters page,
  including the precedence rule (a StorageClass value *replaces* the node
  default, the two are not merged) and how to verify it.
- **xfs troubleshooting rewritten** - the old entry said "kernel 5.10 or higher"
  and offered only a kernel upgrade. The feature that actually breaks the mount
  is `nrext64`, which needs 5.19, and both drivers can now avoid it with a
  format option. Adds the feature/kernel table and both Helm fixes.

## Release notes

- Component versions → Mayastor 2.12.1, Hostpath 4.6.0, LVM 1.10.1,
  ZFS 2.11.1, Rawfile 0.15.1, CLI 4.6.1.
- New entries in the existing sections: format options (What's New), plugin
  output improvements and updatable Rawfile SC/VolumeSnapshotClass
  (Enhancements), labels-with-slashes, support bundle timeout, Rawfile
  copy-on-write auto-detection and Rawfile controller disable (Fixes).
- `version-4.6.x` link anchor → `#release-v4.6.1`.

## Other corrections

- `supportability.md` - `--timeout` default 10s → 30s.
- `eventing-aggregator.md` and `kubectl-plugin.md` - added the `ID` column
  that 2.12.1 introduced to the event output.